### PR TITLE
Add auth0 to backend

### DIFF
--- a/Auth/HasScopeHandler.cs
+++ b/Auth/HasScopeHandler.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Threading.Tasks;
+using CribblyBackend.Auth;
+using Microsoft.AspNetCore.Authorization;
+
+public class HasScopeHandler : AuthorizationHandler<HasScopeRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, HasScopeRequirement requirement)
+    {
+        // If user does not have the scope claim, get out of here
+        if (!context.User.HasClaim(c => c.Type == "scope" && c.Issuer == requirement.Issuer))
+            return Task.CompletedTask;
+
+        // Split the scopes string into an array
+        var scopes = context.User.FindFirst(c => c.Type == "scope" && c.Issuer == requirement.Issuer).Value.Split(' ');
+
+        // Succeed if the scope array contains the required scope
+        if (scopes.Any(s => s == requirement.Scope))
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/Auth/HasScopeRequirement.cs
+++ b/Auth/HasScopeRequirement.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.AspNetCore.Authorization;
+
+namespace CribblyBackend.Auth
+{
+    public class HasScopeRequirement : IAuthorizationRequirement
+    {
+        public string Issuer { get; }
+        public string Scope { get; }
+
+        public HasScopeRequirement(string scope, string issuer)
+        {
+            Scope = scope ?? throw new ArgumentNullException(nameof(scope));
+            Issuer = issuer ?? throw new ArgumentNullException(nameof(issuer));
+        }
+    }
+}

--- a/Controllers/SampleController.cs
+++ b/Controllers/SampleController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CribblyBackend.Controllers
@@ -8,11 +9,29 @@ namespace CribblyBackend.Controllers
     public class SampleController : ControllerBase
     {
         [HttpGet]
-        public async Task<ActionResult<string>> Get()
+        public async Task<IActionResult> Get()
         {
             return await Task.Run(() =>
             {
                 return Ok("Hello, cribbly!");
+            });
+        }
+        [HttpGet("private")]
+        [Authorize]
+        public async Task<IActionResult> GetPrivate()
+        {
+            return await Task.Run(() =>
+            {
+                return Ok("Hello, private cribbly!");
+            });
+        }
+        [HttpGet("private-scoped")]
+        [Authorize("read:sample")]
+        public async Task<IActionResult> GetPrivateScoped()
+        {
+            return await Task.Run(() =>
+            {
+                return Ok("Hello, private cribbly, this is a scoped, protected endpoint!");
             });
         }
     }

--- a/Controllers/SampleController.cs
+++ b/Controllers/SampleController.cs
@@ -25,15 +25,5 @@ namespace CribblyBackend.Controllers
                 return Ok("Hello, private cribbly!");
             });
         }
-        [HttpGet("private-scoped")]
-        [Authorize("read:sample")]
-        public async Task<IActionResult> GetPrivateScoped()
-        {
-            // TODO not sure how to test this yet, can't seem to get an access token with a scope defined.
-            return await Task.Run(() =>
-            {
-                return Ok("Hello, private cribbly, this is a scoped, protected endpoint!");
-            });
-        }
     }
 }

--- a/Controllers/SampleController.cs
+++ b/Controllers/SampleController.cs
@@ -29,6 +29,7 @@ namespace CribblyBackend.Controllers
         [Authorize("read:sample")]
         public async Task<IActionResult> GetPrivateScoped()
         {
+            // TODO not sure how to test this yet, can't seem to get an access token with a scope defined.
             return await Task.Run(() =>
             {
                 return Ok("Hello, private cribbly, this is a scoped, protected endpoint!");

--- a/CribblyBackend.csproj
+++ b/CribblyBackend.csproj
@@ -5,5 +5,10 @@
     <RootNamespace>CribblyBackend</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.10" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
+  </ItemGroup>
+
 
 </Project>

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,15 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using System.Security.Claims;
+using CribblyBackend.Auth;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 
 namespace CribblyBackend
 {
@@ -26,6 +24,26 @@ namespace CribblyBackend
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
+
+            string domain = $"https://{Configuration["Auth0:Domain"]}/";
+            services
+                .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(options =>
+                {
+                    options.Authority = domain;
+                    options.Audience = Configuration["Auth0:Audience"];
+                    // If the access token does not have a `sub` claim, `User.Identity.Name` will be `null`. Map it to a different claim by setting the NameClaimType below.
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        NameClaimType = ClaimTypes.NameIdentifier
+                    };
+                });
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("read:messages", policy => policy.Requirements.Add(new HasScopeRequirement("read:messages", domain)));
+            });
+
+            services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -35,13 +53,10 @@ namespace CribblyBackend
             {
                 app.UseDeveloperExceptionPage();
             }
-
             app.UseHttpsRedirection();
-
             app.UseRouting();
-
+            app.UseAuthentication();
             app.UseAuthorization();
-
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();

--- a/Startup.cs
+++ b/Startup.cs
@@ -40,7 +40,7 @@ namespace CribblyBackend
                 });
             services.AddAuthorization(options =>
             {
-                options.AddPolicy("read:messages", policy => policy.Requirements.Add(new HasScopeRequirement("read:messages", domain)));
+                options.AddPolicy("read:sample", policy => policy.Requirements.Add(new HasScopeRequirement("read:sample", domain)));
             });
 
             services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();

--- a/appsettings.json
+++ b/appsettings.json
@@ -6,5 +6,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Auth0": {
+    "Domain": "dev-ib-rt2lw.us.auth0.com",
+    "Audience": "https://cribbly.com/api"
+  }
 }


### PR DESCRIPTION
# What I added (link any issues addressed)
- Basic Auth0 integration to protect API endpoints
  - Followed [this](https://auth0.com/docs/quickstart/backend/aspnet-core-webapi/01-authorization)

# How to test it
- Run the backend locally
- Try to `GET` from `https://localhost:5001/sample` and see that it works
- Try to `GET` from `https://localhost:5001/sample/private` and see that it doesn't
- Get an access token from Auth0 (ask me for the client ID and secret for this)
- Try to `GET` from `https://localhost:5001/sample/private` with the `authorization` header set to `Bearer $THE_TOKEN` and see that it now works

I still don't quite know how the scopes work, but I did add a scoped endpoint as well. I don't know how to get an Auth0 token with the proper scopes to see that endpoint. Not sure we'll need it anyway.
