### PR TITLE
Connect db

### DIFF
--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -17,9 +17,15 @@ namespace CribblyBackend.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetByEmail([FromBody] Player player)
+        [Route("{email}")]
+        public async Task<IActionResult> GetByEmail(string email)
         {
-            return Ok(await playerService.GetByEmail(player.Email));
+            var p = await playerService.GetByEmail(email);
+            if (p != null)
+            {
+                return Ok(await playerService.GetByEmail(email));
+            }
+            return NotFound();
         }
 
         [HttpPost]

--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -17,8 +17,7 @@ namespace CribblyBackend.Controllers
         }
 
         [HttpGet]
-        [Route("{email}")]
-        public async Task<IActionResult> GetByEmail(string email)
+        public async Task<IActionResult> GetByEmail([FromQuery] string email)
         {
             var p = await playerService.GetByEmail(email);
             if (p != null)

--- a/Controllers/PlayerController.cs
+++ b/Controllers/PlayerController.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+using CribblyBackend.Models;
+using CribblyBackend.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CribblyBackend.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class PlayerController : ControllerBase
+    {
+        private readonly IPlayerService playerService;
+        public PlayerController(IPlayerService playerService)
+        {
+            this.playerService = playerService;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetByEmail([FromBody] Player player)
+        {
+            return Ok(await playerService.GetByEmail(player.Email));
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] Player player)
+        {
+            try
+            {
+                await playerService.Create(player);
+            }
+            catch (Exception e)
+            {
+                return StatusCode(500, $"Uh oh, bad time: {e.Message}");
+            }
+            return Ok();
+        }
+    }
+}

--- a/CribblyBackend.csproj
+++ b/CribblyBackend.csproj
@@ -1,14 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>CribblyBackend</RootNamespace>
+    <UserSecretsId>6fcb902c-390b-4a8c-8a94-c56999a8b33b</UserSecretsId>
   </PropertyGroup>
-
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.78" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.10" />
+    <PackageReference Include="MySql.Data" Version="8.0.22" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
   </ItemGroup>
-
-
 </Project>

--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -4,9 +4,10 @@ namespace CribblyBackend.Models
 {
     public class Player
     {
-        public string Name { get; set; }
+        public int Id { get; set; }
         public string Email { get; set; }
-        public bool HasTeam { get; set; }
+        public string Name { get; set; }
+        public Team Team { get; set; }
         public string Role { get; set; }
     }
 }

--- a/Models/Team.cs
+++ b/Models/Team.cs
@@ -4,6 +4,7 @@ namespace CribblyBackend.Models
 {
     public class Team
     {
+        public int Id { get; set; }
         public string Name { get; set; }
         public string Division { get; set; }
         public List<Player> Players { get; set; }

--- a/Services/PlayerService.cs
+++ b/Services/PlayerService.cs
@@ -1,0 +1,66 @@
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using CribblyBackend.Models;
+using Dapper;
+
+namespace CribblyBackend.Services
+{
+    public interface IPlayerService
+    {
+        void Initialize();
+        Task<Player> GetByEmail(string email);
+        void Update(Player player);
+        Task Create(Player player);
+        void Delete(Player player);
+    }
+    public class PlayerService : IPlayerService
+    {
+        IDbConnection connection;
+        public PlayerService(IDbConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public async Task Create(Player player)
+        {
+            await connection.ExecuteAsync(
+                @"INSERT INTO Players (Email, Name, Team, Role)
+                VALUES (@Email, @Name, @Team, @Role)",
+                new { Email = player.Email, Name = player.Name, Team = player.Team?.Id, Role = player.Role }
+            );
+        }
+
+        public void Delete(Player player)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public async Task<Player> GetByEmail(string email)
+        {
+            var players = await connection.QueryAsync<Player>(
+                @"SELECT * FROM Players WHERE Email = @Email",
+                new { Email = email }
+            );
+            return players.FirstOrDefault();
+        }
+
+        public void Initialize()
+        {
+            connection.Execute(
+                @"CREATE TABLE IF NOT EXISTS Players (
+                    Id INT AUTO_INCREMENT PRIMARY KEY,
+                    Email VARCHAR(100) NOT NULL,
+                    Name VARCHAR(100) NOT NULL,
+                    Team INT,
+                    Role VARCHAR(100)
+                );"
+            );
+        }
+
+        public void Update(Player player)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,5 +1,7 @@
+using System.Data;
 using System.Security.Claims;
 using CribblyBackend.Auth;
+using CribblyBackend.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -8,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
+using MySql.Data.MySqlClient;
 
 namespace CribblyBackend
 {
@@ -44,10 +47,12 @@ namespace CribblyBackend
             });
 
             services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
+            services.AddTransient<IDbConnection>(db => new MySqlConnection(Configuration["MySQL:ConnectionString"]));
+            services.AddTransient<IPlayerService, PlayerService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IPlayerService playerService)
         {
             if (env.IsDevelopment())
             {
@@ -61,6 +66,8 @@ namespace CribblyBackend
             {
                 endpoints.MapControllers();
             });
+
+            playerService.Initialize();
         }
     }
 }


### PR DESCRIPTION
# What I added (link any issues addressed)
- a basic connection to a MySQL db using Dapper
- a basic `PlayerService` to abstract away the database details
- a basic `PlayerController` to handle incoming requests

# How to test it
The trickiest part here is getting MySQL set up properly. As far as the application is concerned, the main thing you need to do is set a connection string that ASP.NET can access. I did this using the [secret manager](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-5.0&tabs=linux#secret-manager). To test this PR, you'll need to do the following
```bash
dotnet user-secrets init
dotnet user-secrets set "MySQL:ConnectionString" "{connectionString}"
```
I used a connection string for my local MySQL instance, but you could always set up a test db in the cloud somewhere if that's easier. There are also other ways aside from the secret manager to get things into the app's configuration, like adding the connection string to `appsettings.json` with a key of `MySQL:ConnectionString`, but we don't want to commit connection strings to GitHub.

Okay, once you have your db set up, you can run the server and `POST` a player to `https://localhost:5001/player`. The body should be a json-ified version of `Player.cs`:
```json
{
    "name": "Tobias Funke",
    "email": "anustart@bluth.com"
}
```
Currently, you can omit or include anything (including Role, so in the future, we'll want to make sure the role can't be set via the API).

Then, you can `GET` the player by email at `https://localhost:5001/player?email=anustart@bluth.com` which returns:
```json
{
    "id": 3,
    "email": "anustart@bluth.com",
    "name": "Tobias Funke",
    "team": null,
    "role": null
}
```