### PR TITLE
Add fluent migrator

### DIFF
--- a/CribblyBackend.csproj
+++ b/CribblyBackend.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.78" />
+    <PackageReference Include="FluentMigrator" Version="3.2.10" />
+    <PackageReference Include="FluentMigrator.Runner" Version="3.2.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.10" />
     <PackageReference Include="MySql.Data" Version="8.0.22" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />

--- a/Migrations/20201219_AddPlayerTable.cs
+++ b/Migrations/20201219_AddPlayerTable.cs
@@ -7,19 +7,19 @@ namespace CribblyBackend.Migrations
     {
         public override void Down()
         {
-            Delete.Table("Teams");
             Delete.Table("Players");
+            Delete.Table("Teams");
         }
 
         public override void Up()
         {
             Create.Table("Teams")
-                .WithColumn("Id").AsInt32().PrimaryKey();
+                .WithColumn("Id").AsInt32().PrimaryKey().Identity();
             Create.Table("Players")
-                .WithColumn("Id").AsInt32().PrimaryKey()
+                .WithColumn("Id").AsInt32().PrimaryKey().Identity()
                 .WithColumn("Email").AsString(255).NotNullable().Unique()
-                .WithColumn("Name").AsString(255)
-                .WithColumn("Role").AsString(255)
+                .WithColumn("Name").AsString(255).Nullable()
+                .WithColumn("Role").AsString(255).Nullable()
                 .WithColumn("TeamId").AsInt32().ForeignKey("Teams", "Id").Nullable();
         }
     }

--- a/Migrations/20201219_AddPlayerTable.cs
+++ b/Migrations/20201219_AddPlayerTable.cs
@@ -20,7 +20,7 @@ namespace CribblyBackend.Migrations
                 .WithColumn("Email").AsString(255).NotNullable().Unique()
                 .WithColumn("Name").AsString(255)
                 .WithColumn("Role").AsString(255)
-                .WithColumn("TeamId").AsInt32().ForeignKey("Teams", "Id");
+                .WithColumn("TeamId").AsInt32().ForeignKey("Teams", "Id").Nullable();
         }
     }
 }

--- a/Migrations/20201219_AddPlayerTable.cs
+++ b/Migrations/20201219_AddPlayerTable.cs
@@ -1,0 +1,26 @@
+using FluentMigrator;
+
+namespace CribblyBackend.Migrations
+{
+    [Migration(20201219100700)]
+    public class AddPlayerTable : Migration
+    {
+        public override void Down()
+        {
+            Delete.Table("Teams");
+            Delete.Table("Players");
+        }
+
+        public override void Up()
+        {
+            Create.Table("Teams")
+                .WithColumn("Id").AsInt32().PrimaryKey();
+            Create.Table("Players")
+                .WithColumn("Id").AsInt32().PrimaryKey()
+                .WithColumn("Email").AsString(255).NotNullable().Unique()
+                .WithColumn("Name").AsString(255)
+                .WithColumn("Role").AsString(255)
+                .WithColumn("TeamId").AsInt32().ForeignKey("Teams", "Id");
+        }
+    }
+}

--- a/Services/PlayerService.cs
+++ b/Services/PlayerService.cs
@@ -8,7 +8,6 @@ namespace CribblyBackend.Services
 {
     public interface IPlayerService
     {
-        void Initialize();
         Task<Player> GetByEmail(string email);
         void Update(Player player);
         Task Create(Player player);
@@ -43,19 +42,6 @@ namespace CribblyBackend.Services
                 new { Email = email }
             );
             return players.FirstOrDefault();
-        }
-
-        public void Initialize()
-        {
-            connection.Execute(
-                @"CREATE TABLE IF NOT EXISTS Players (
-                    Id INT AUTO_INCREMENT PRIMARY KEY,
-                    Email VARCHAR(100) NOT NULL,
-                    Name VARCHAR(100) NOT NULL,
-                    Team INT,
-                    Role VARCHAR(100)
-                );"
-            );
         }
 
         public void Update(Player player)

--- a/Services/PlayerService.cs
+++ b/Services/PlayerService.cs
@@ -24,9 +24,9 @@ namespace CribblyBackend.Services
         public async Task Create(Player player)
         {
             await connection.ExecuteAsync(
-                @"INSERT INTO Players (Email, Name, Team, Role)
-                VALUES (@Email, @Name, @Team, @Role)",
-                new { Email = player.Email, Name = player.Name, Team = player.Team?.Id, Role = player.Role }
+                @"INSERT INTO Players (Email, Name, TeamId, Role)
+                VALUES (@Email, @Name, @TeamId, @Role)",
+                new { Email = player.Email, Name = player.Name, TeamId = player.Team?.Id, Role = player.Role }
             );
         }
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,7 +1,9 @@
 using System.Data;
+using System.Reflection;
 using System.Security.Claims;
 using CribblyBackend.Auth;
 using CribblyBackend.Services;
+using FluentMigrator.Runner;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -45,6 +47,11 @@ namespace CribblyBackend
             {
                 options.AddPolicy("read:sample", policy => policy.Requirements.Add(new HasScopeRequirement("read:sample", domain)));
             });
+            services.AddFluentMigratorCore()
+                .ConfigureRunner(c => c
+                    .AddMySql5()
+                    .WithGlobalConnectionString(Configuration["MySQL:ConnectionString"])
+                    .ScanIn(Assembly.GetExecutingAssembly()).For.All());
 
             services.AddSingleton<IAuthorizationHandler, HasScopeHandler>();
             services.AddTransient<IDbConnection>(db => new MySqlConnection(Configuration["MySQL:ConnectionString"]));
@@ -52,7 +59,7 @@ namespace CribblyBackend
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IPlayerService playerService)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IMigrationRunner migrationRunner)
         {
             if (env.IsDevelopment())
             {
@@ -66,8 +73,7 @@ namespace CribblyBackend
             {
                 endpoints.MapControllers();
             });
-
-            playerService.Initialize();
+            migrationRunner.MigrateUp();
         }
     }
 }


### PR DESCRIPTION
# What I added (link any issues addressed)
Okay, so this is super cool. I added FluentMigrator, which allows us to write and execute db migrations. Check out my migration here as an example; I'm using the form yyyyMMddmm as the ID for migrations, that way they'll always be increasing as time goes on. A nice TODO would be to create a CL tool that autocreates a template migration with that filled in...

ANYWAY. We can now alter the db with migrations instead of manual SQL queries in an `Initialize` method.
# How to test it
Make sure your cribbly db is cleared out (delete all tables). Run the app. See that it creates a Teams table and a Players table with the appropriate columns.

If you want to revert the migration, you can change L76 in `Startup.cs` to:
`migrationRunner.MigrateDown(0);`
And rerun the app.

I'm especially excited about this because it automigrates every time the server starts up. You do have to be a bit careful when writing your migrations. I had some trouble setting the correct column attributes to be able to store users again. But if you screw something up you can always migrate down or add another migration to fix it!
