### PR TITLE
Add login endpoint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+# What I added (link any issues addressed)
+
+# How to test it

--- a/CribblyBackend.UnitTests/ControllerTests/PlayerControllerTests.cs
+++ b/CribblyBackend.UnitTests/ControllerTests/PlayerControllerTests.cs
@@ -104,7 +104,7 @@ namespace CribblyBackend.UnitTests
         [Fact]
         public async Task Create_ShouldReturnOk_IfNoError()
         {
-            mockPlayerService.Setup(x => x.Create(It.IsAny<Player>()));
+            mockPlayerService.Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>()));
 
             var result = await playerController.Create(new Player());
 
@@ -114,7 +114,8 @@ namespace CribblyBackend.UnitTests
         [Fact]
         public async Task Create_ShouldReturn500_IfError()
         {
-            mockPlayerService.Setup(x => x.Create(It.IsAny<Player>())).Throws(new Exception());
+            mockPlayerService.Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>()))
+                .Throws(new Exception());
 
             var result = await playerController.Create(new Player());
 

--- a/CribblyBackend.UnitTests/ControllerTests/PlayerControllerTests.cs
+++ b/CribblyBackend.UnitTests/ControllerTests/PlayerControllerTests.cs
@@ -103,28 +103,6 @@ namespace CribblyBackend.UnitTests
         }
 
         [Fact]
-        public async Task Create_ShouldReturnOk_IfNoError()
-        {
-            mockPlayerService.Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>()));
-
-            var result = await playerController.Create(new Player());
-
-            Assert.IsType<OkResult>(result);
-        }
-
-        [Fact]
-        public async Task Create_ShouldReturn500_IfError()
-        {
-            mockPlayerService.Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>()))
-                .Throws(new Exception());
-
-            var result = await playerController.Create(new Player());
-
-            var typedResult = Assert.IsType<ObjectResult>(result);
-            Assert.Equal(StatusCodes.Status500InternalServerError, typedResult.StatusCode);
-        }
-
-        [Fact]
         public async Task Login_ShouldReturn400_IfNoEmail()
         {
             var result = await playerController.Login(new LoginRequest());

--- a/CribblyBackend/Controllers/PlayerController.cs
+++ b/CribblyBackend/Controllers/PlayerController.cs
@@ -25,25 +25,33 @@ namespace CribblyBackend.Controllers
         /// <param name="request">The request</param>
         /// <returns></returns>
         [HttpPost("login")]
-        public async Task<LoginResponse> Login([FromBody] LoginRequest request)
+        public async Task<IActionResult> Login([FromBody] LoginRequest request)
         {
+            if (request.Email == null)
+            {
+                return BadRequest("Must provide an email");
+            }
             var exists = await playerService.Exists(request.Email);
             Player player;
             if (exists)
             {
                 player = await playerService.GetByEmail(request.Email);
-                return new LoginResponse()
+                return Ok(new LoginResponse()
                 {
                     Player = player,
                     IsReturning = true,
-                };
+                });
+            }
+            if (request.Name == null)
+            {
+                return BadRequest("Must provide a name if the specified player doesn't exist");
             }
             player = await playerService.Create(request.Email, request.Name);
-            return new LoginResponse()
+            return Ok(new LoginResponse()
             {
                 Player = player,
                 IsReturning = false,
-            };
+            });
         }
 
         /// <summary>

--- a/CribblyBackend/Controllers/PlayerController.cs
+++ b/CribblyBackend/Controllers/PlayerController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using CribblyBackend.Models;
+using CribblyBackend.Models.Network;
 using CribblyBackend.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -16,6 +17,33 @@ namespace CribblyBackend.Controllers
         public PlayerController(IPlayerService playerService)
         {
             this.playerService = playerService;
+        }
+
+        /// <summary>
+        /// Handles the login. Creates or gets the player specified in the request.
+        /// </summary>
+        /// <param name="request">The request</param>
+        /// <returns></returns>
+        [HttpPost]
+        public async Task<LoginResponse> Login([FromBody] LoginRequest request)
+        {
+            var exists = await playerService.Exists(request.Email);
+            Player player;
+            if (exists)
+            {
+                player = await playerService.GetByEmail(request.Email);
+                return new LoginResponse()
+                {
+                    Player = player,
+                    IsReturning = true,
+                };
+            }
+            player = await playerService.Create(request.Email, request.Name);
+            return new LoginResponse()
+            {
+                Player = player,
+                IsReturning = false,
+            };
         }
 
         /// <summary>
@@ -65,7 +93,7 @@ namespace CribblyBackend.Controllers
         {
             try
             {
-                await playerService.Create(player);
+                await playerService.Create(player.Email, player.Name);
             }
             catch (Exception e)
             {

--- a/CribblyBackend/Controllers/PlayerController.cs
+++ b/CribblyBackend/Controllers/PlayerController.cs
@@ -24,7 +24,7 @@ namespace CribblyBackend.Controllers
         /// </summary>
         /// <param name="request">The request</param>
         /// <returns></returns>
-        [HttpPost]
+        [HttpPost("login")]
         public async Task<LoginResponse> Login([FromBody] LoginRequest request)
         {
             var exists = await playerService.Exists(request.Email);

--- a/CribblyBackend/Controllers/PlayerController.cs
+++ b/CribblyBackend/Controllers/PlayerController.cs
@@ -90,24 +90,5 @@ namespace CribblyBackend.Controllers
             }
             return NotFound();
         }
-
-        /// <summary>
-        /// Create creates the specified player.
-        /// </summary>
-        /// <param name="player">The player to create</param>
-        /// <returns></returns>
-        [HttpPost]
-        public async Task<IActionResult> Create([FromBody] Player player)
-        {
-            try
-            {
-                await playerService.Create(player.Email, player.Name);
-            }
-            catch (Exception e)
-            {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Error: {e.Message}");
-            }
-            return Ok();
-        }
     }
 }

--- a/CribblyBackend/Models/Network/LoginRequest.cs
+++ b/CribblyBackend/Models/Network/LoginRequest.cs
@@ -1,0 +1,8 @@
+namespace CribblyBackend.Models.Network
+{
+    public class LoginRequest
+    {
+        public string Email { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/CribblyBackend/Models/Network/LoginResponse.cs
+++ b/CribblyBackend/Models/Network/LoginResponse.cs
@@ -1,0 +1,8 @@
+namespace CribblyBackend.Models.Network
+{
+    public class LoginResponse
+    {
+        public Player Player { get; set; }
+        public bool IsReturning { get; set; }
+    }
+}

--- a/CribblyBackend/Services/PlayerService.cs
+++ b/CribblyBackend/Services/PlayerService.cs
@@ -9,10 +9,11 @@ namespace CribblyBackend.Services
 {
     public interface IPlayerService
     {
+        Task<bool> Exists(string email);
         Task<Player> GetByEmail(string email);
         Task<Player> GetById(int id);
         void Update(Player player);
-        Task Create(Player player);
+        Task<Player> Create(string email, string name);
         void Delete(Player player);
     }
     public class PlayerService : IPlayerService
@@ -23,13 +24,22 @@ namespace CribblyBackend.Services
             this.connection = connection;
         }
 
-        public async Task Create(Player player)
+        public async Task<bool> Exists(string email)
+        {
+            return (await connection.QueryAsync<bool>(
+                @"SELECT EXISTS(SELECT * FROM Players WHERE Email = @Email LIMIT 1)",
+                new { Email = email }
+            )).First();
+        }
+
+        public async Task<Player> Create(string email, string name)
         {
             await connection.ExecuteAsync(
                 @"INSERT INTO Players (Email, Name, TeamId, Role)
                 VALUES (@Email, @Name, @TeamId, @Role)",
-                new { Email = player.Email, Name = player.Name, TeamId = player.Team?.Id, Role = player.Role }
+                new { Email = email, Name = name }
             );
+            return await GetByEmail(email);
         }
 
         public void Delete(Player player)

--- a/CribblyBackend/Services/PlayerService.cs
+++ b/CribblyBackend/Services/PlayerService.cs
@@ -35,8 +35,7 @@ namespace CribblyBackend.Services
         public async Task<Player> Create(string email, string name)
         {
             await connection.ExecuteAsync(
-                @"INSERT INTO Players (Email, Name, TeamId, Role)
-                VALUES (@Email, @Name, @TeamId, @Role)",
+                @"INSERT INTO Players (Email, Name) VALUES (@Email, @Name)",
                 new { Email = email, Name = name }
             );
             return await GetByEmail(email);

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 .PHONY: test
 test:
 	dotnet test CribblyBackend.UnitTests
+
+.PHONY: serve
+serve:
+	dotnet run --project CribblyBackend


### PR DESCRIPTION
Oops, I think I accidentally wiped out the PR template at some point. This PR adds that back in, but the main point of this PR is:

- Added a login endpoint which gets or creates a user given an email and name
- The endpoint returns a response which indicates whether the player is returning or not (so we can display "welcome back" or just "welcome" on the home page)
- Did a bit of reworking the player service to better match our use case