### PR TITLE
Update tournament controller

### DIFF
--- a/CribblyBackend.UnitTests/ControllerTests/TournamentControllerTests.cs
+++ b/CribblyBackend.UnitTests/ControllerTests/TournamentControllerTests.cs
@@ -1,0 +1,152 @@
+using System;
+using CribblyBackend.Controllers;
+using CribblyBackend.Models;
+using CribblyBackend.Models.Network;
+using CribblyBackend.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Cribbly.UnitTessts
+{
+    public class TournamentControllerTests
+    {
+        private readonly Mock<ITournamentService> mockTournamentService;
+        private readonly TournamentController tournamentController;
+        public TournamentControllerTests()
+        {
+            mockTournamentService = new Mock<ITournamentService>();
+            tournamentController = new TournamentController(mockTournamentService.Object);
+        }
+
+        [Fact]
+        public async void GetNextTournament_ShouldReturnNotFound_IfNoTournamentFound()
+        {
+            mockTournamentService.Setup(x => x.GetNextTournament()).ReturnsAsync((Tournament)null);
+
+            var result = Assert.IsType<NotFoundResult>(await tournamentController.GetNextTournament());
+        }
+
+        [Fact]
+        public async void GetNextTournament_ShouldReturnOkAndTournament_IfTournamentFound()
+        {
+            var testTournament = new Tournament()
+            {
+                Id = 123
+            };
+            mockTournamentService.Setup(x => x.GetNextTournament()).ReturnsAsync(testTournament);
+
+            var result = Assert.IsType<OkObjectResult>(await tournamentController.GetNextTournament());
+            var tournament = Assert.IsType<Tournament>(result.Value);
+            Assert.Equal(testTournament.Id, tournament.Id);
+        }
+
+        [Fact]
+        public async void Create_ShouldReturnOk_IfTournamentCreated()
+        {
+            var testDate = new DateTime(2020, 1, 1);
+            var request = new CreateTournamentRequest() { Date = testDate };
+            mockTournamentService.Setup(x => x.Create(testDate));
+
+            var result = Assert.IsType<OkResult>(await tournamentController.CreateTournament(request));
+            mockTournamentService.VerifyAll();
+        }
+
+        [Fact]
+        public async void Create_ShouldReturnError_IfTournamentCreateFails()
+        {
+            var testDate = new DateTime(2020, 1, 1);
+            var request = new CreateTournamentRequest() { Date = testDate };
+            mockTournamentService.Setup(x => x.Create(It.IsAny<DateTime>())).ThrowsAsync(new Exception("Bad time"));
+
+            var result = Assert.IsType<ObjectResult>(await tournamentController.CreateTournament(request));
+            Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+        }
+
+        [Fact]
+        public async void ChangeTournamentFlags_ReturnsBadRequest_IfNoFlagsInRequest()
+        {
+            var request = new ChangeTournamentFlagsRequest() { Id = 123 };
+
+            var result = Assert.IsType<BadRequestObjectResult>(await tournamentController.ChangeTournamentFlags(request));
+        }
+
+        [Fact]
+        public async void ChangeTournamentFlags_ChangesFlags_AndReturnsOk()
+        {
+            var isActive = true;
+            var isOpenForRegistration = false;
+            var request = new ChangeTournamentFlagsRequest()
+            {
+                Id = 123,
+                IsActive = isActive,
+                IsOpenForRegistration = isOpenForRegistration,
+            };
+            mockTournamentService.Setup(x => x.ChangeActiveStatus(request.Id, isActive));
+            mockTournamentService.Setup(x => x.ChangeOpenForRegistrationStatus(request.Id, isOpenForRegistration));
+
+            var result = Assert.IsType<OkResult>(await tournamentController.ChangeTournamentFlags(request));
+            mockTournamentService.VerifyAll();
+        }
+
+        [Fact]
+        public async void ChangeTournamentFlags_DoesNotCallChangeActiveStatus_IfIsActiveIsNull()
+        {
+            bool? isActive = null;
+            var isOpenForRegistration = false;
+            var request = new ChangeTournamentFlagsRequest()
+            {
+                Id = 123,
+                IsActive = isActive,
+                IsOpenForRegistration = isOpenForRegistration,
+            };
+            mockTournamentService.Setup(x => x.ChangeActiveStatus(request.Id, It.IsAny<bool>()));
+            mockTournamentService.Setup(x => x.ChangeOpenForRegistrationStatus(request.Id, isOpenForRegistration));
+
+            await tournamentController.ChangeTournamentFlags(request);
+
+            mockTournamentService.Verify(x => x.ChangeActiveStatus(It.IsAny<int>(), It.IsAny<bool>()), Times.Never());
+        }
+
+        [Fact]
+        public async void ChangeTournamentFlags_DoesNotCallChangeOpenForRegistrationStatus_IfIsOpenForRegistrationIsNull()
+        {
+            var isActive = false;
+            bool? isOpenForRegistration = null;
+            var request = new ChangeTournamentFlagsRequest()
+            {
+                Id = 123,
+                IsActive = isActive,
+                IsOpenForRegistration = isOpenForRegistration,
+            };
+            mockTournamentService.Setup(x => x.ChangeActiveStatus(request.Id, isActive));
+            mockTournamentService.Setup(x => x.ChangeOpenForRegistrationStatus(request.Id, It.IsAny<bool>()));
+
+            await tournamentController.ChangeTournamentFlags(request);
+
+            mockTournamentService.Verify(x => x.ChangeOpenForRegistrationStatus(It.IsAny<int>(), It.IsAny<bool>()), Times.Never());
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(null, true)]
+        [InlineData(true, null)]
+        public async void ChangeTournamentFlags_ReturnsError_IfCallToChangeFlagsThrows(
+            bool? isActive,
+            bool? isOpenForRegistration)
+        {
+            var request = new ChangeTournamentFlagsRequest()
+            {
+                Id = 123,
+                IsActive = isActive,
+                IsOpenForRegistration = isOpenForRegistration
+            };
+            mockTournamentService.Setup(x => x.ChangeActiveStatus(request.Id, It.IsAny<bool>())).ThrowsAsync(new Exception());
+            mockTournamentService.Setup(x => x.ChangeOpenForRegistrationStatus(request.Id, It.IsAny<bool>())).ThrowsAsync(new Exception());
+
+            var result = Assert.IsType<ObjectResult>(await tournamentController.ChangeTournamentFlags(request));
+            Assert.Equal(StatusCodes.Status500InternalServerError, result.StatusCode);
+        }
+    }
+}

--- a/CribblyBackend.UnitTests/CribblyBackend.UnitTests.csproj
+++ b/CribblyBackend.UnitTests/CribblyBackend.UnitTests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="moq" Version="4.15.2" />
+    <PackageReference Include="Moq.Dapper" Version="1.0.3" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/CribblyBackend.UnitTests/ServiceTests/TournamentServiceTests.cs
+++ b/CribblyBackend.UnitTests/ServiceTests/TournamentServiceTests.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using CribblyBackend.Controllers;
+using CribblyBackend.Models;
+using CribblyBackend.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using Dapper;
+using Moq.Dapper;
+using System.Data;
+using System.Data.Common;
+
+namespace CribblyBackend.UnitTests
+{
+    public class TournamentServiceTests
+    {
+        private readonly TournamentService tournamentService;
+        private readonly Mock<DbConnection> mockConnection;
+
+        public TournamentServiceTests()
+        {
+            mockConnection = new Mock<DbConnection>();
+            tournamentService = new TournamentService(mockConnection.Object);
+        }
+
+        [Fact]
+        public async Task GetNextTournament_ShouldReturnNull_WhenNoTournamentsAreOpenForRegistration()
+        {
+            mockConnection
+                .SetupDapperAsync(c => c.QueryAsync<Tournament>(It.IsAny<string>(), It.IsAny<object>(), null, null, null))
+                .ReturnsAsync(new List<Tournament>());
+
+            var tournament = await tournamentService.GetNextTournament();
+            Assert.Null(tournament);
+        }
+
+        [Fact]
+        public async Task GetNextTournament_ShouldReturnTournamentOpenForRegistration_WhenSuccessful()
+        {
+            var activeDate = new DateTime(2021, 3, 1);
+            var mockTournaments = new List<Tournament>()
+            {
+                new Tournament() { Date = activeDate },
+            };
+            mockConnection
+                .SetupDapperAsync(c => c.QueryAsync<Tournament>(It.IsAny<string>(), It.IsAny<object>(), null, null, null))
+                .ReturnsAsync(mockTournaments);
+
+            var tournament = await tournamentService.GetNextTournament();
+            Assert.Equal(activeDate, tournament.Date);
+        }
+
+        [Fact]
+        public async Task GetNextTournament_ShouldThrowError_WhenQueryFindsTwoTournamentsOpenForRegistration()
+        {
+            var mockTournaments = new List<Tournament>()
+            {
+                new Tournament() { Date = new DateTime(1992, 3, 10) },
+                new Tournament() { Date = new DateTime(1995, 4, 14) },
+            };
+            mockConnection
+                .SetupDapperAsync(x => x.QueryAsync<Tournament>(It.IsAny<string>(), It.IsAny<object>(), null, null, null))
+                .ReturnsAsync(mockTournaments);
+
+            await Assert.ThrowsAsync<Exception>(async () => await tournamentService.GetNextTournament());
+        }
+
+        [Fact]
+        public async Task ChangeActiveStatus_ShouldUpdateDatabase_WhenCanActivateTournament()
+        {
+            var tournamentId = 123;
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.QueryAsync<Tournament>(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(new List<Tournament> { });
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.ExecuteAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(1);
+
+            // Since Moq.Dapper doesn't support Verify* Moq methods, best we can do is test that no error is thrown
+            await tournamentService.ChangeActiveStatus(tournamentId, true);
+        }
+
+        [Fact]
+        public async Task ChangeActiveStatus_ShouldUpdateDatabase_WhenCanDeactivateTournament()
+        {
+            var tournamentId = 123;
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.QueryAsync<Tournament>(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(new List<Tournament> { new Tournament { IsActive = true } });
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.ExecuteAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(1);
+
+            // Since Moq.Dapper doesn't support Verify* Moq methods, best we can do is test that no error is thrown
+            await tournamentService.ChangeActiveStatus(tournamentId, false);
+        }
+
+        [Theory]
+        [MemberData(nameof(ChangeActiveStatus_ErrorTests_Data))]
+        public async Task ChangeActiveStatus_ShouldThrowErrors(bool newVal, List<Tournament> mockQueryResult)
+        {
+            var tournamentId = 123;
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.QueryAsync<Tournament>(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(mockQueryResult);
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.ExecuteAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(1);
+
+            await Assert.ThrowsAsync<Exception>(async () => await tournamentService.ChangeActiveStatus(tournamentId, newVal));
+        }
+
+        public static IEnumerable<object[]> ChangeActiveStatus_ErrorTests_Data =>
+            new List<object[]>
+            {
+                // trying to activate a tourney when one already is active
+                new object[] { true, new List<Tournament> { new Tournament { } } },
+                // trying to deactivate a tourney when none are active
+                new object[] { false, new List<Tournament> { new Tournament { } } },
+                // trying to deactivate a tourney when more than one are active
+                new object[] { false, new List<Tournament> { new Tournament { }, new Tournament { } } },
+                // trying to deactivate a tourney when the returned tourney isn't active
+                new object[] { false, new List<Tournament> { new Tournament { IsActive = false } } },
+            };
+
+        [Fact]
+        public async Task ChangeOpenForRegistrationStatus_ShouldUpdateDatabase_WhenCanOpenTournament()
+        {
+            var tournamentId = 123;
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.QueryAsync<Tournament>(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(new List<Tournament> { });
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.ExecuteAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(1);
+
+            // Since Moq.Dapper doesn't support Verify* Moq methods, best we can do is test that no error is thrown
+            await tournamentService.ChangeOpenForRegistrationStatus(tournamentId, true);
+        }
+
+
+        [Fact]
+        public async Task ChangeOpenForRegistrationStatus_ShouldUpdateDatabase_WhenCanCloseTournament()
+        {
+            var tournamentId = 123;
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.QueryAsync<Tournament>(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(new List<Tournament> { new Tournament { IsOpenForRegistration = true } });
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.ExecuteAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(1);
+
+            // Since Moq.Dapper doesn't support Verify* Moq methods, best we can do is test that no error is thrown
+            await tournamentService.ChangeOpenForRegistrationStatus(tournamentId, false);
+        }
+
+        [Theory]
+        [MemberData(nameof(ChangeOpenForRegistration_ErrorTests_Data))]
+        public async Task ChangeOpenForRegistrationStatus_ShouldThrowErrors(bool newVal, List<Tournament> mockQueryResult)
+        {
+            var tournamentId = 123;
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.QueryAsync<Tournament>(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(mockQueryResult);
+            mockConnection
+                .SetupDapperAsync(
+                    x => x.ExecuteAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        null,
+                        null,
+                        null))
+                .ReturnsAsync(1);
+
+            await Assert.ThrowsAsync<Exception>(async () => await tournamentService.ChangeOpenForRegistrationStatus(tournamentId, newVal));
+        }
+
+        public static IEnumerable<object[]> ChangeOpenForRegistration_ErrorTests_Data =>
+            new List<object[]>
+            {
+                // trying to open a tourney when one already is open
+                new object[] { true, new List<Tournament> { new Tournament { } } },
+                // trying to close a tourney when none are open
+                new object[] { false, new List<Tournament> { new Tournament { } } },
+                // trying to close a tourney when more than one are open
+                new object[] { false, new List<Tournament> { new Tournament { }, new Tournament { } } },
+                // trying to close a tourney when the returned tourney isn't open
+                new object[] { false, new List<Tournament> { new Tournament { IsOpenForRegistration = false } } },
+            };
+
+    }
+}

--- a/CribblyBackend/Controllers/TournamentController.cs
+++ b/CribblyBackend/Controllers/TournamentController.cs
@@ -1,6 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using CribblyBackend.Services;
 using System.Threading.Tasks;
+using CribblyBackend.Models;
+using CribblyBackend.Models.Network;
+using Microsoft.AspNetCore.Http;
+using System;
 
 namespace CribblyBackend.Controllers
 {
@@ -14,7 +18,7 @@ namespace CribblyBackend.Controllers
             this.tournamentService = tournamentService;
         }
 
-        [HttpGet]
+        [HttpGet("next")]
         public async Task<IActionResult> GetNextTournament()
         {
             var nextTournament = await tournamentService.GetNextTournament();
@@ -23,6 +27,20 @@ namespace CribblyBackend.Controllers
                 return NotFound();
             }
             return Ok(nextTournament);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateTournament([FromBody] CreateTournamentRequest request)
+        {
+            try
+            {
+                await tournamentService.Create(request.Date);
+                return Ok();
+            }
+            catch (Exception e)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, $"Bad time: ${e.Message}");
+            }
         }
     }
 }

--- a/CribblyBackend/Controllers/TournamentController.cs
+++ b/CribblyBackend/Controllers/TournamentController.cs
@@ -39,7 +39,33 @@ namespace CribblyBackend.Controllers
             }
             catch (Exception e)
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Bad time: ${e.Message}");
+                return StatusCode(StatusCodes.Status500InternalServerError, $"Bad time: {e.Message}");
+            }
+        }
+
+        [HttpPost("setFlags")]
+        public async Task<IActionResult> ChangeTournamentFlags([FromBody] ChangeTournamentFlagsRequest request)
+        {
+            if (!request.IsActive.HasValue && !request.IsOpenForRegistration.HasValue)
+            {
+                return BadRequest("Must set at least one flag");
+            }
+            try
+            {
+
+                if (request.IsActive.HasValue)
+                {
+                    await tournamentService.ChangeActiveStatus(request.Id, request.IsActive.Value);
+                }
+                if (request.IsOpenForRegistration.HasValue)
+                {
+                    await tournamentService.ChangeOpenForRegistrationStatus(request.Id, request.IsOpenForRegistration.Value);
+                }
+                return Ok();
+            }
+            catch (Exception e)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, $"Bad time: {e.Message}");
             }
         }
     }

--- a/CribblyBackend/Controllers/TournamentController.cs
+++ b/CribblyBackend/Controllers/TournamentController.cs
@@ -1,30 +1,28 @@
 using Microsoft.AspNetCore.Mvc;
-using CribblyBackend.Models;
-using System.Collections.Generic;
+using CribblyBackend.Services;
+using System.Threading.Tasks;
 
 namespace CribblyBackend.Controllers
 {
     [ApiController]
-    [Route("/[controller]")]
+    [Route("api/[controller]")]
     public class TournamentController : ControllerBase
     {
-        [HttpGet]
-        public Tournament Get()
+        private readonly ITournamentService tournamentService;
+        public TournamentController(ITournamentService tournamentService)
         {
-            //Generate mock data and return to client
-            Tournament tournament = new Tournament();
-            tournament.Games = new List<Game>();
-                Game testgame1 = new Game();
-                Game testgame2 = new Game();
-                tournament.Games.Add(testgame1);
-                tournament.Games.Add(testgame2);
-            tournament.Teams = new List<Team>();
-                tournament.Teams.Add(new Team());
-            tournament.Players = new List<Player>();
-                tournament.Players.Add(new Player());
-            tournament.Year = 2021;
+            this.tournamentService = tournamentService;
+        }
 
-            return tournament;
+        [HttpGet]
+        public async Task<IActionResult> GetNextTournament()
+        {
+            var nextTournament = await tournamentService.GetNextTournament();
+            if (nextTournament == null)
+            {
+                return NotFound();
+            }
+            return Ok(nextTournament);
         }
     }
 }

--- a/CribblyBackend/Migrations/20210111052959_PersistTournaments.cs
+++ b/CribblyBackend/Migrations/20210111052959_PersistTournaments.cs
@@ -1,0 +1,20 @@
+using FluentMigrator;
+
+namespace CribblyBackend.Migrations
+{
+    [Migration(20210111052959)]
+    public class PersistTournaments : Migration
+    {
+        public override void Down()
+        {
+            Delete.Table("Tournaments");
+        }
+
+        public override void Up()
+        {
+            Create.Table("Tournaments")
+                .WithColumn("Id").AsInt32().PrimaryKey().Identity()
+                .WithColumn("Date").AsDateTime().NotNullable();
+        }
+    }
+}

--- a/CribblyBackend/Migrations/20210112083704_AddTournamentFlags.cs
+++ b/CribblyBackend/Migrations/20210112083704_AddTournamentFlags.cs
@@ -1,0 +1,21 @@
+using FluentMigrator;
+
+namespace CribblyBackend.Migrations
+{
+    [Migration(20210112083704)]
+    public class AddTournamentFlags : Migration
+    {
+        public override void Down()
+        {
+            Delete.Column("IsOpenForRegistration").FromTable("Tournaments");
+            Delete.Column("IsActive").FromTable("Tournaments");
+        }
+
+        public override void Up()
+        {
+            Alter.Table("Tournaments")
+                .AddColumn("IsOpenForRegistration").AsBoolean().NotNullable()
+                .AddColumn("IsActive").AsBoolean().NotNullable();
+        }
+    }
+}

--- a/CribblyBackend/Models/Network/ChangeTournamentFlagsRequest.cs
+++ b/CribblyBackend/Models/Network/ChangeTournamentFlagsRequest.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace CribblyBackend.Models.Network
+{
+    public class ChangeTournamentFlagsRequest
+    {
+        public int Id { get; set; }
+        public bool? IsActive { get; set; }
+        public bool? IsOpenForRegistration { get; set; }
+    }
+}

--- a/CribblyBackend/Models/Network/CreateTournamentRequest.cs
+++ b/CribblyBackend/Models/Network/CreateTournamentRequest.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace CribblyBackend.Models.Network
+{
+    public class CreateTournamentRequest
+    {
+        public DateTime Date { get; set; }
+    }
+}

--- a/CribblyBackend/Models/Tournament.cs
+++ b/CribblyBackend/Models/Tournament.cs
@@ -1,10 +1,12 @@
+using System;
 using System.Collections.Generic;
 
 namespace CribblyBackend.Models
 {
     public class Tournament
     {
-        public int Year { get; set; }
+        public int Id { get; set; }
+        public DateTime Date { get; set; }
         public List<Player> Players { get; set; }
         public List<Team> Teams { get; set; }
         public List<Game> Games { get; set; }

--- a/CribblyBackend/Models/Tournament.cs
+++ b/CribblyBackend/Models/Tournament.cs
@@ -7,6 +7,8 @@ namespace CribblyBackend.Models
     {
         public int Id { get; set; }
         public DateTime Date { get; set; }
+        public bool IsOpenForRegistration { get; set; }
+        public bool IsActive { get; set; }
         public List<Player> Players { get; set; }
         public List<Team> Teams { get; set; }
         public List<Game> Games { get; set; }

--- a/CribblyBackend/Services/TournamentService.cs
+++ b/CribblyBackend/Services/TournamentService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ namespace CribblyBackend.Services
     public interface ITournamentService
     {
         Task<Tournament> GetNextTournament();
-        Task<Tournament> Create(Tournament tournament);
+        Task<Tournament> Create(DateTime date);
     }
     public class TournamentService : ITournamentService
     {
@@ -18,11 +19,11 @@ namespace CribblyBackend.Services
         {
             this.connection = connection;
         }
-        public async Task<Tournament> Create(Tournament tournament)
+        public async Task<Tournament> Create(DateTime date)
         {
             await connection.ExecuteAsync(
                 @"INSERT INTO Tournaments (Date) VALUES (@Date)",
-                new { Date = tournament.Date }
+                new { Date = date }
             );
             return (await connection.QueryAsync<Tournament>(
                 @"SELECT * FROM Tournaments WHERE Id = LAST_INSERT_ID()"

--- a/CribblyBackend/Services/TournamentService.cs
+++ b/CribblyBackend/Services/TournamentService.cs
@@ -32,13 +32,13 @@ namespace CribblyBackend.Services
 
         public async Task<Tournament> GetNextTournament()
         {
-            return (await connection.QueryAsync<Tournament>(
+            var tournaments = await connection.QueryAsync<Tournament>(
                 @"
                 SELECT * FROM Tournaments
                 ORDER BY Date ASC
-                LIMIT 1
                 "
-            )).FirstOrDefault();
+            );
+            return tournaments.Where(t => t.Date.Date >= DateTime.Today).FirstOrDefault();
         }
     }
 }

--- a/CribblyBackend/Services/TournamentService.cs
+++ b/CribblyBackend/Services/TournamentService.cs
@@ -1,0 +1,43 @@
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using CribblyBackend.Models;
+using Dapper;
+
+namespace CribblyBackend.Services
+{
+    public interface ITournamentService
+    {
+        Task<Tournament> GetNextTournament();
+        Task<Tournament> Create(Tournament tournament);
+    }
+    public class TournamentService : ITournamentService
+    {
+        private readonly IDbConnection connection;
+        public TournamentService(IDbConnection connection)
+        {
+            this.connection = connection;
+        }
+        public async Task<Tournament> Create(Tournament tournament)
+        {
+            await connection.ExecuteAsync(
+                @"INSERT INTO Tournaments (Date) VALUES (@Date)",
+                new { Date = tournament.Date }
+            );
+            return (await connection.QueryAsync<Tournament>(
+                @"SELECT * FROM Tournaments WHERE Id = LAST_INSERT_ID()"
+            )).First();
+        }
+
+        public async Task<Tournament> GetNextTournament()
+        {
+            return (await connection.QueryAsync<Tournament>(
+                @"
+                SELECT * FROM Tournaments
+                ORDER BY Date ASC
+                LIMIT 1
+                "
+            )).FirstOrDefault();
+        }
+    }
+}

--- a/CribblyBackend/Services/TournamentService.cs
+++ b/CribblyBackend/Services/TournamentService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +13,8 @@ namespace CribblyBackend.Services
     {
         Task<Tournament> GetNextTournament();
         Task<Tournament> Create(DateTime date);
+        Task ChangeActiveStatus(int tournamentId, bool newVal);
+        Task ChangeOpenForRegistrationStatus(int tournamentId, bool newVal);
     }
     public class TournamentService : ITournamentService
     {
@@ -22,7 +26,10 @@ namespace CribblyBackend.Services
         public async Task<Tournament> Create(DateTime date)
         {
             await connection.ExecuteAsync(
-                @"INSERT INTO Tournaments (Date) VALUES (@Date)",
+                @"
+                INSERT INTO Tournaments (Date, IsOpenForRegistration, IsActive) 
+                VALUES (@Date, FALSE, FALSE)
+                ",
                 new { Date = date }
             );
             return (await connection.QueryAsync<Tournament>(
@@ -32,13 +39,86 @@ namespace CribblyBackend.Services
 
         public async Task<Tournament> GetNextTournament()
         {
-            var tournaments = await connection.QueryAsync<Tournament>(
+            var tournaments = (await connection.QueryAsync<Tournament>(
                 @"
                 SELECT * FROM Tournaments
-                ORDER BY Date ASC
+                WHERE IsOpenForRegistration = TRUE
                 "
-            );
-            return tournaments.Where(t => t.Date.Date >= DateTime.Today).FirstOrDefault();
+            )).ToList();
+            if (tournaments.Count == 0)
+            {
+                // No tournament has been scheduled
+                return null;
+            }
+            if (tournaments.Count > 1)
+            {
+                throw new Exception("There can't be two tournaments simultaneously open for registration");
+            }
+            return tournaments.First();
+        }
+
+        public async Task ChangeActiveStatus(int tournamentId, bool newVal)
+        {
+            await SetFlagValue(tournamentId, nameof(Tournament.IsActive), newVal);
+        }
+        public async Task ChangeOpenForRegistrationStatus(int tournamentId, bool newVal)
+        {
+            await SetFlagValue(tournamentId, nameof(Tournament.IsOpenForRegistration), newVal);
+        }
+
+        private async Task SetFlagValue(int tournamentId, string flagName, bool newVal)
+        {
+            var activeTournaments = (await connection.QueryAsync<Tournament>(
+                @"SELECT * FROM Tournaments WHERE @Name = TRUE",
+                new { Name = flagName }
+            )).ToList();
+            var (canSetValue, errMessage) = CanSetFlag(newVal, flagName, activeTournaments);
+            if (!canSetValue)
+            {
+                throw new Exception($"{errMessage} [attempted to change {flagName} status of {tournamentId}]");
+            }
+            await connection.ExecuteAsync(
+                @"
+                UPDATE Tournaments 
+                SET @Name = @Value 
+                WHERE Id = @Id
+                ",
+                new { Name = flagName, Value = newVal, Id = tournamentId }
+                );
+        }
+
+        private (bool, string) CanSetFlag(bool newVal, string flagName, List<Tournament> resultsWithFlagSet)
+        {
+            if (newVal)
+            {
+                if (resultsWithFlagSet.Count != 0)
+                {
+                    // can't set flag is a tournament already has the flag active
+                    var idList = string.Join(", ", resultsWithFlagSet.Select(t => t.Id.ToString()));
+                    return (false, $"Cannot set {flagName}; it is already set on tournament(s) {idList}");
+                }
+                // return early; nothing more to check if we're setting to true
+                return (true, "");
+            }
+            // Now we're unsetting a flag
+            if (resultsWithFlagSet.Count != 1)
+            {
+                // There should be exactly one tournament with the flag set if we're unsetting it
+                return (false, $"Cannot unset {flagName}; there is not exactly one tournament with this flag set");
+            }
+            // At this point we know there's only one result so can safely call First()
+            var result = resultsWithFlagSet.First();
+            var isActiveFlagInvalid =
+                flagName == nameof(Tournament.IsActive) && !result.IsActive;
+            var isOpenForRegistrationFlagInvalid =
+                flagName == nameof(Tournament.IsOpenForRegistration) && !result.IsOpenForRegistration;
+
+            if (isActiveFlagInvalid || isOpenForRegistrationFlagInvalid)
+            {
+                // The tournament we're unsetting the flag on should have it set
+                return (false, $"Cannot unset {flagName}; it isn't set on the specified tournament");
+            }
+            return (true, "");
         }
     }
 }

--- a/CribblyBackend/Startup.cs
+++ b/CribblyBackend/Startup.cs
@@ -1,7 +1,5 @@
 using System.Data;
 using System.Reflection;
-using System.Security.Claims;
-using CribblyBackend.Auth;
 using CribblyBackend.Services;
 using FluentMigrator.Runner;
 using Microsoft.AspNetCore.Authentication.JwtBearer;

--- a/CribblyBackend/Startup.cs
+++ b/CribblyBackend/Startup.cs
@@ -57,6 +57,7 @@ namespace CribblyBackend
             services.AddTransient<IPlayerService, PlayerService>();
             services.AddTransient<ITeamService, TeamService>();
             services.AddTransient<IGameService, GameService>();
+            services.AddTransient<ITournamentService, TournamentService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
# What I added (link any issues addressed)
- I reworked the tournament controller to start to be able to persist tournaments
- For now, I have a create endpoint (for testing; we'll want to look at this more closely when we get deeper into it, and an endpoint to get the next tournament
- The goal with this PR is to provide the backend functionality to be able to display the next tournament date on the landing page in the front end (right now the value is just hard coded)

# How to test it
- Run the server locally
- POST a tournament to `localhost:5001/tournament`. The request object only has a date on it. I'm not sure exactly what date formats are allowed, but this template definitely works:
```json
{
    "date": "YYYY-MM-DD"
}
```
- GET from `localhost:5001/tournament/next`. This should return the next tournament according to today's date, and shouldn't take the time of day into effect at all. This is so that on the night of the tournament, we're always getting that tournament. Could be an issue if the tournament goes past midnight... I'd like to hear any ideas you have on how to make that more robust.
- Try creating some past tournaments and future tournaments in the DB; make sure the GET always returns the one that's next in the future
