### PR TITLE
Add CI with nice test reports

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,69 @@
+name: .NET Core Build with Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    # use ubuntu for more build minutes
+    runs-on: ubuntu-latest
+    # use release mode for all steps
+    env:
+      config: 'Release'
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+
+        # restore dependencies
+      - name: Install dependencies
+        run: dotnet restore
+
+        # build project
+      - name: Build
+        run: dotnet build --configuration $config --no-restore
+
+        # set pr number, if it's a pr build
+      - name: set pr build number
+        id: PRNUMBER
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: kkak10/pr-number-action@v1.3
+
+        # set report file and title
+      - name: Set Test Title
+        run: |
+          if ${{ github.event_name == 'pull_request' }}
+          then
+            echo "::set-env name=title::Test Run for PR #${{steps.PRNUMBER.outputs.pr}} (${{github.run_number}})"
+            echo "::set-env name=file_name::TestReport.${{steps.PRNUMBER.outputs.pr}}.${{github.run_number}}.md"
+          else
+            echo "::set-env name=title::Test Run ${{github.run_number}}"
+            echo "::set-env name=file_name::TestReport.${{github.run_number}}.md"
+          fi
+
+        # run tests with built project
+      - name: Test PR
+        run: dotnet test --no-restore --no-build --configuration $config --logger:"liquid.md;LogFileName=${{github.workspace}}/${{env.file_name}};Title=${{env.title}};"
+
+        # upload report as build artifact
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        if: ${{always()}}
+        with:
+          name: 'Test Run'
+          path: ${{github.workspace}}/${{env.file_name}}
+
+        # add report as PR comment (if PR)
+      - name: comment PR
+        uses: machine-learning-apps/pr-comment@master
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: ${{env.file_name}}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,11 +23,11 @@ jobs:
 
         # restore dependencies
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore CribblyBackend.UnitTests
 
         # build project
       - name: Build
-        run: dotnet build --configuration $config --no-restore
+        run: dotnet build CribblyBackend.UnitTests --configuration $config --no-restore
 
         # set pr number, if it's a pr build
       - name: set pr build number
@@ -49,7 +49,7 @@ jobs:
 
         # run tests with built project
       - name: Test PR
-        run: dotnet test --no-restore --no-build --configuration $config --logger:"liquid.md;LogFileName=${{github.workspace}}/${{env.file_name}};Title=${{env.title}};"
+        run: dotnet test CribblyBackend.UnitTests --no-restore --no-build --configuration $config --logger:"liquid.md;LogFileName=${{github.workspace}}/${{env.file_name}};Title=${{env.title}};"
 
         # upload report as build artifact
       - name: Upload a Build Artifact

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: .NET Core Build with Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,11 +40,11 @@ jobs:
         run: |
           if ${{ github.event_name == 'pull_request' }}
           then
-            echo "::set-env name=title::Test Run for PR #${{steps.PRNUMBER.outputs.pr}} (${{github.run_number}})"
-            echo "::set-env name=file_name::TestReport.${{steps.PRNUMBER.outputs.pr}}.${{github.run_number}}.md"
+            echo "title='Test Run for PR #${{steps.PRNUMBER.outputs.pr}} (${{github.run_number}})'" >> $GITHUB_ENV
+            echo "file_name=TestReport.${{steps.PRNUMBER.outputs.pr}}.${{github.run_number}}.md" >> $GITHUB_ENV
           else
-            echo "::set-env name=title::Test Run ${{github.run_number}}"
-            echo "::set-env name=file_name::TestReport.${{github.run_number}}.md"
+            echo "title='Test Run ${{github.run_number}}'" >> $GITHUB_ENV
+            echo "file_name=TestReport.${{github.run_number}}.md" >> $GITHUB_ENV
           fi
 
         # run tests with built project

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build:
-    # use ubuntu for more build minutes
     runs-on: ubuntu-latest
-    # use release mode for all steps
     env:
       config: 'Release'
 
@@ -21,21 +19,17 @@ jobs:
         with:
           dotnet-version: 3.1.101
 
-        # restore dependencies
-      - name: Install dependencies
+      - name: Install Dependencies
         run: dotnet restore CribblyBackend.UnitTests
 
-        # build project
       - name: Build
         run: dotnet build CribblyBackend.UnitTests --configuration $config --no-restore
 
-        # set pr number, if it's a pr build
-      - name: set pr build number
+      - name: Set PR Number
         id: PRNUMBER
         if: ${{ github.event_name == 'pull_request' }}
         uses: kkak10/pr-number-action@v1.3
 
-        # set report file and title
       - name: Set Test Title
         run: |
           if ${{ github.event_name == 'pull_request' }}
@@ -47,20 +41,17 @@ jobs:
             echo "file_name=TestReport.${{github.run_number}}.md" >> $GITHUB_ENV
           fi
 
-        # run tests with built project
       - name: Test PR
         run: dotnet test CribblyBackend.UnitTests --no-restore --no-build --configuration $config --logger:"liquid.md;LogFileName=${{github.workspace}}/${{env.file_name}};Title=${{env.title}};"
 
-        # upload report as build artifact
-      - name: Upload a Build Artifact
+      - name: Upload Report
         uses: actions/upload-artifact@v2
         if: ${{always()}}
         with:
           name: 'Test Run'
           path: ${{github.workspace}}/${{env.file_name}}
 
-        # add report as PR comment (if PR)
-      - name: comment PR
+      - name: Comment PR
         uses: machine-learning-apps/pr-comment@master
         if: ${{ github.event_name == 'pull_request' }}
         env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,10 +40,10 @@ jobs:
         run: |
           if ${{ github.event_name == 'pull_request' }}
           then
-            echo "title='Test Run for PR #${{steps.PRNUMBER.outputs.pr}} (${{github.run_number}})'" >> $GITHUB_ENV
+            echo "title=Test Run for PR #${{steps.PRNUMBER.outputs.pr}} (${{github.run_number}})" >> $GITHUB_ENV
             echo "file_name=TestReport.${{steps.PRNUMBER.outputs.pr}}.${{github.run_number}}.md" >> $GITHUB_ENV
           else
-            echo "title='Test Run ${{github.run_number}}'" >> $GITHUB_ENV
+            echo "title=Test Run ${{github.run_number}}" >> $GITHUB_ENV
             echo "file_name=TestReport.${{github.run_number}}.md" >> $GITHUB_ENV
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ msbuild.wrn
 
 # Visual Studio 2015
 .vs/
+
+TestResults

--- a/CribblyBackend.UnitTests/CribblyBackend.UnitTests.csproj
+++ b/CribblyBackend.UnitTests/CribblyBackend.UnitTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LiquidTestReports.Markdown" Version="1.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="moq" Version="4.15.2" />
     <PackageReference Include="Moq.Dapper" Version="1.0.3" />


### PR DESCRIPTION
# What I added (link any issues addressed)
I followed the instructions [here](https://dev.to/kurtmkurtm/testing-net-core-apps-with-github-actions-3i76) to set up a bit of CI for us. Check below to see the result - it'll add a test report to any PR.
# How to test it
Not much to test; take a look at the report below. Once we have this merged and you pull `main` into your branches (or create new branches), this'll run on all PR commits.
