### PR TITLE
Add all teams endpoint

### DIFF
--- a/CribblyBackend.UnitTests/ControllerTests/TeamControllerTests.cs
+++ b/CribblyBackend.UnitTests/ControllerTests/TeamControllerTests.cs
@@ -94,7 +94,7 @@ namespace CribblyBackend.UnitTests
             }
 
 
-            mockTeamService.Setup(x => x.GetAll());
+            mockTeamService.Setup(x => x.GetAll()).ReturnsAsync(expTeams);
             var result = await TeamController.GetAll();
             var okResult = Assert.IsType<OkObjectResult>(result);
             var actTeams = Assert.IsType<List<Team>>(okResult.Value);

--- a/CribblyBackend.UnitTests/ControllerTests/TeamControllerTests.cs
+++ b/CribblyBackend.UnitTests/ControllerTests/TeamControllerTests.cs
@@ -95,10 +95,10 @@ namespace CribblyBackend.UnitTests
 
 
             mockTeamService.Setup(x => x.GetAll()).ReturnsAsync(expTeams);
-            var result = await TeamController.GetAll();
+            var result = await TeamController.Get();
             var okResult = Assert.IsType<OkObjectResult>(result);
             var actTeams = Assert.IsType<List<Team>>(okResult.Value);
-            Assert.Equal(expTeams.Count, actTeams.Count);
+            Assert.Equal(expTeams, actTeams);
             foreach (Team team in actTeams)
             {
                 Assert.Equal(2, team.Players.Count);

--- a/CribblyBackend.UnitTests/ControllerTests/TeamControllerTests.cs
+++ b/CribblyBackend.UnitTests/ControllerTests/TeamControllerTests.cs
@@ -69,6 +69,41 @@ namespace CribblyBackend.UnitTests
             Assert.Equal(expTeam.Name, actTeam.Name);
             Assert.Equal(expTeam.Players, actTeam.Players);
         }
+        [Fact]
+        public async Task GetAll_ShouldReturnTeamsAndOkStatus()
+        {
+            var expTeams = new List<Team>();
+            for (int i = 1; i <= 30; i++)
+            {
+                Team team = new Team()
+                {
+                    Id = i,
+                    Name = $"test Team {i}",
+                    Players = new List<Player>()
+                };
+                for (int j = 1; j <= 2; j++)
+                {
+                    Player expPlayer = new Player()
+                    {
+                        Id = i,
+                        Email = $"test{i}@test.com",
+                        Name = $"test player {i}"
+                    };
+                    team.Players.Add(expPlayer);
+                }
+            }
+
+
+            mockTeamService.Setup(x => x.GetAll());
+            var result = await TeamController.GetAll();
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var actTeams = Assert.IsType<List<Team>>(okResult.Value);
+            Assert.Equal(expTeams.Count, actTeams.Count);
+            foreach (Team team in actTeams)
+            {
+                Assert.Equal(2, team.Players.Count);
+            }
+        }
 
         [Fact]
         public async Task Create_ShouldReturnOkAndCreatedId_IfNoError()

--- a/CribblyBackend.UnitTests/ControllerTests/TeamControllerTests.cs
+++ b/CribblyBackend.UnitTests/ControllerTests/TeamControllerTests.cs
@@ -94,7 +94,7 @@ namespace CribblyBackend.UnitTests
             }
 
 
-            mockTeamService.Setup(x => x.GetAll()).ReturnsAsync(expTeams);
+            mockTeamService.Setup(x => x.Get()).ReturnsAsync(expTeams);
             var result = await TeamController.Get();
             var okResult = Assert.IsType<OkObjectResult>(result);
             var actTeams = Assert.IsType<List<Team>>(okResult.Value);

--- a/CribblyBackend.UnitTests/ServiceTests/TeamServiceTests.cs
+++ b/CribblyBackend.UnitTests/ServiceTests/TeamServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using CribblyBackend.Controllers;
+using CribblyBackend.DataAccess.Models;
+using CribblyBackend.DataAccess.Repositories;
+using CribblyBackend.Services;
+using Dapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.Dapper;
+using Xunit;
+
+namespace CribblyBackend.UnitTests
+{
+    public class TeamServiceTests
+    {
+        private readonly TeamService teamService;
+        private readonly GameService gameService;
+        private readonly Mock<ITeamRepository> mockTeamRepository;
+        private readonly Mock<IGameRepository> mockGameRepository;
+
+        public TeamServiceTests()
+        {
+            mockTeamRepository = new Mock<ITeamRepository>();
+            mockGameRepository = new Mock<IGameRepository>();
+            gameService = new GameService(mockGameRepository.Object);
+            teamService = new TeamService(mockTeamRepository.Object, mockGameRepository.Object);
+        }
+
+    }
+}

--- a/src/CribblyBackend.DataAccess/Migrations/20210318091908_AddStandingsData.cs
+++ b/src/CribblyBackend.DataAccess/Migrations/20210318091908_AddStandingsData.cs
@@ -1,0 +1,29 @@
+using FluentMigrator;
+
+namespace CribblyBackend.Migrations
+{
+    [Migration(20210318091908)]
+    public class AddStandingsData : Migration
+    {
+        public override void Down()
+        {
+            Delete.Column("Division").FromTable("Teams");
+            Delete.Column("Wins").FromTable("Teams");
+            Delete.Column("Losses").FromTable("Teams");
+            Delete.Column("TotalScore").FromTable("Teams");
+            Delete.Column("Seed").FromTable("Teams");
+            Delete.Column("InTournament").FromTable("Teams");
+        }
+
+        public override void Up()
+        {
+            Alter.Table("Teams")
+                .AddColumn("Division").AsString()
+                .AddColumn("Wins").AsInt32()
+                .AddColumn("Losses").AsInt32()
+                .AddColumn("TotalScore").AsInt32()
+                .AddColumn("Seed").AsInt32()
+                .AddColumn("InTournament").AsBoolean();
+        }
+    }
+}

--- a/src/CribblyBackend.DataAccess/Migrations/20210321073238_EditStandingsData.cs
+++ b/src/CribblyBackend.DataAccess/Migrations/20210321073238_EditStandingsData.cs
@@ -1,0 +1,31 @@
+using FluentMigrator;
+
+namespace CribblyBackend.Migrations
+{
+    [Migration(20210321073238)]
+    public class EditStandingsData : Migration
+    {
+        public override void Down()
+        {
+            Alter.Table("Teams")
+                .AddColumn("Division").AsString()
+                .AddColumn("Wins").AsInt32()
+                .AddColumn("Losses").AsInt32()
+                .AddColumn("TotalScore").AsInt32()
+                .AddColumn("Seed").AsInt32()
+                .AddColumn("InTournament").AsBoolean();
+        }
+
+        public override void Up()
+        {
+            Delete.Column("Division").FromTable("Teams");
+            Delete.Column("Wins").FromTable("Teams");
+            Delete.Column("Losses").FromTable("Teams");
+            Delete.Column("TotalScore").FromTable("Teams");
+            Delete.Column("Seed").FromTable("Teams");
+            Delete.Column("InTournament").FromTable("Teams");
+            Alter.Table("Teams")
+                .AddColumn("Division").AsInt32();
+        }
+    }
+}

--- a/src/CribblyBackend.DataAccess/Migrations/20210324100011_AddDivisionsTable.cs
+++ b/src/CribblyBackend.DataAccess/Migrations/20210324100011_AddDivisionsTable.cs
@@ -1,0 +1,20 @@
+using FluentMigrator;
+
+namespace CribblyBackend.Migrations
+{
+    [Migration(20210324100011)]
+    public class AddDivisionsTable : Migration
+    {
+        public override void Down()
+        {
+            Delete.Table("Teams");
+        }
+
+        public override void Up()
+        {
+            Create.Table("Divisions")
+                .WithColumn("Id").AsInt32().PrimaryKey().Identity()
+                .WithColumn("Name").AsString();
+        }
+    }
+}

--- a/src/CribblyBackend.DataAccess/Migrations/20210324110320_EditDivisions.cs
+++ b/src/CribblyBackend.DataAccess/Migrations/20210324110320_EditDivisions.cs
@@ -2,12 +2,11 @@ using FluentMigrator;
 
 namespace CribblyBackend.Migrations
 {
-    [Migration(20210324100011)]
-    public class AddDivisionsTable : Migration
+    [Migration(20210324110320)]
+    public class EditDivisions : Migration
     {
         public override void Down()
         {
-            Delete.Table("Divisions");
             Delete.Column("Division").FromTable("Teams");
             Alter.Table("Teams")
                 .AddColumn("Division").AsInt32();
@@ -15,9 +14,7 @@ namespace CribblyBackend.Migrations
 
         public override void Up()
         {
-            Create.Table("Divisions")
-                .WithColumn("Id").AsInt32().PrimaryKey().Identity()
-                .WithColumn("Name").AsString();
+
             Delete.Column("Division").FromTable("Teams");
             Alter.Table("Teams")
                 .AddColumn("Division").AsInt32().ForeignKey("Divisions", "Id").Nullable();

--- a/src/CribblyBackend.DataAccess/Models/Team.cs
+++ b/src/CribblyBackend.DataAccess/Models/Team.cs
@@ -6,7 +6,7 @@ namespace CribblyBackend.DataAccess.Models
     {
         public int Id { get; set; }
         public string Name { get; set; }
-        public Division Division { get; set; }
+        public int Division { get; set; }
         public List<Player> Players { get; set; }
         public List<int> GameScores { get; set; }
         public List<Game> PlayInGames { get; set; }

--- a/src/CribblyBackend.DataAccess/Models/Team.cs
+++ b/src/CribblyBackend.DataAccess/Models/Team.cs
@@ -6,7 +6,7 @@ namespace CribblyBackend.DataAccess.Models
     {
         public int Id { get; set; }
         public string Name { get; set; }
-        public string Division { get; set; }
+        public Division Division { get; set; }
         public List<Player> Players { get; set; }
         public List<int> GameScores { get; set; }
         public List<Game> PlayInGames { get; set; }

--- a/src/CribblyBackend.DataAccess/Models/Team.cs
+++ b/src/CribblyBackend.DataAccess/Models/Team.cs
@@ -6,7 +6,7 @@ namespace CribblyBackend.DataAccess.Models
     {
         public int Id { get; set; }
         public string Name { get; set; }
-        public int Division { get; set; }
+        public Division Division { get; set; }
         public List<Player> Players { get; set; }
         public List<int> GameScores { get; set; }
         public List<Game> PlayInGames { get; set; }

--- a/src/CribblyBackend.DataAccess/Repositories/TeamRepository.cs
+++ b/src/CribblyBackend.DataAccess/Repositories/TeamRepository.cs
@@ -10,6 +10,7 @@ namespace CribblyBackend.DataAccess.Repositories
     public interface ITeamRepository
     {
         Task<Team> GetById(int Id);
+        Task<List<Team>> GetAll();
         void Update(Team Team);
         Task<int> Create(Team Team);
         void Delete(Team Team);
@@ -21,7 +22,32 @@ namespace CribblyBackend.DataAccess.Repositories
         {
             _connection = connection;
         }
+        public async Task<List<Team>> GetAll()
+        {
+            var players = new List<Player>();
+            var teams = (await _connection.QueryAsync<Team, Player, Team>(
+                @"SELECT * FROM Teams t INNER JOIN Players p ON t.Id = p.TeamId",
+                (t, p) => 
+                {
+                    switch (players.Count)
+                    {
+                        case 0:
+                            players.Add(p);
+                            break;
+                        case 1:
+                            players.Add(p);
+                            t.Players = new List<Player>();
+                            t.Players.AddRange(players);
+                            players.Clear();
+                            break;
+                    }
 
+                    return t;
+                },
+                splitOn: "Id"
+                )).Where(t => t.Players != null).ToList();
+            return teams;
+        }
         public async Task<int> Create(Team team)
         {
             if (team.Players.Count < 2)

--- a/src/CribblyBackend.DataAccess/Services/TeamComparer.cs
+++ b/src/CribblyBackend.DataAccess/Services/TeamComparer.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using CribblyBackend.DataAccess.Models;
+
+namespace CribblyBackend.DataAccess.Services
+{
+    public class TeamComparer : IEqualityComparer<Team>
+    {
+        public bool Equals(Team team1, Team team2)
+        {
+            return team1.Id == team2.Id;
+        }
+
+        public int GetHashCode(Team team)
+        {
+            if(team == null) return 0;
+            unchecked
+            {
+                int hash = 69;
+                hash = (hash * 420) + team.Id;
+                return hash;
+            }
+        }
+    }
+}

--- a/src/CribblyBackend/Controllers/TeamController.cs
+++ b/src/CribblyBackend/Controllers/TeamController.cs
@@ -68,7 +68,7 @@ namespace CribblyBackend.Controllers
             try
             {
                 logger.Debug("Received request to get all teams");
-                var teams = await teamService.GetAll();
+                var teams = await teamService.Get();
                 logger.Debug("All teams returned");
                 return Ok(teams);
             }

--- a/src/CribblyBackend/Controllers/TeamController.cs
+++ b/src/CribblyBackend/Controllers/TeamController.cs
@@ -63,8 +63,7 @@ namespace CribblyBackend.Controllers
         /// GetAll returns all teams that are in the active tournament. 
         /// </summary>
         /// <returns></returns>
-        [HttpGet("GetAll")]
-        public async Task<IActionResult> GetAll()
+        public async Task<IActionResult> Get()
         {
             try
             {

--- a/src/CribblyBackend/Controllers/TeamController.cs
+++ b/src/CribblyBackend/Controllers/TeamController.cs
@@ -59,5 +59,25 @@ namespace CribblyBackend.Controllers
                 return StatusCode(500, $"Uh oh, bad time: {e.Message}");
             }
         }
+        /// <summary>
+        /// GetAll returns all teams that are in the active tournament. 
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("GetAll")]
+        public async Task<IActionResult> GetAll()
+        {
+            try
+            {
+                logger.Debug("Received request to get all teams");
+                var teams = await teamService.GetAll();
+                logger.Debug("All teams returned");
+                return Ok(teams);
+            }
+            catch (Exception e)
+            {
+                logger.Information(e, "Failed to fetch all teams");
+                return StatusCode(500, $"Uh oh, bad time: {e.Message}");
+            }
+        }
     }
 }

--- a/src/CribblyBackend/Services/TeamService.cs
+++ b/src/CribblyBackend/Services/TeamService.cs
@@ -8,7 +8,7 @@ namespace CribblyBackend.Services
     public interface ITeamService
     {
         Task<Team> GetById(int Id);
-        Task<List<Team>> GetAll();
+        Task<List<Team>> Get();
         void Update(Team Team);
         Task<int> Create(Team Team);
         void Delete(Team Team);
@@ -16,14 +16,21 @@ namespace CribblyBackend.Services
     public class TeamService : ITeamService
     {
         private readonly ITeamRepository _teamRepository;
+        private readonly IGameRepository _gameRepository;
 
-        public TeamService(ITeamRepository teamRepository)
+        public TeamService(ITeamRepository teamRepository, IGameRepository gameRepository)
         {
             _teamRepository = teamRepository;
+            _gameRepository = gameRepository;
         }
-        public async Task<List<Team>> GetAll()
+        public async Task<List<Team>> Get()
         {
-            return await _teamRepository.GetAll();
+            var teams = await _teamRepository.Get();
+            foreach (Team team in teams)
+            {
+
+            }
+            return teams;
         }
         public async Task<int> Create(Team team)
         {

--- a/src/CribblyBackend/Services/TeamService.cs
+++ b/src/CribblyBackend/Services/TeamService.cs
@@ -28,7 +28,7 @@ namespace CribblyBackend.Services
             var teams = await _teamRepository.Get();
             foreach (Team team in teams)
             {
-
+                //TODO: Calculate wins, losses, 
             }
             return teams;
         }

--- a/src/CribblyBackend/Services/TeamService.cs
+++ b/src/CribblyBackend/Services/TeamService.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using CribblyBackend.DataAccess.Models;
 using CribblyBackend.DataAccess.Repositories;
 
@@ -7,6 +8,7 @@ namespace CribblyBackend.Services
     public interface ITeamService
     {
         Task<Team> GetById(int Id);
+        Task<List<Team>> GetAll();
         void Update(Team Team);
         Task<int> Create(Team Team);
         void Delete(Team Team);
@@ -19,7 +21,10 @@ namespace CribblyBackend.Services
         {
             _teamRepository = teamRepository;
         }
-
+        public async Task<List<Team>> GetAll()
+        {
+            return await _teamRepository.GetAll();
+        }
         public async Task<int> Create(Team team)
         {
             return await _teamRepository.Create(team);


### PR DESCRIPTION
# What I added (link any issues addressed)
This endpoint will be the start for fetching team standings in the tournament. I added the rest of the Team object properties to the database, and set up this endpoint so that player names will be returned with the teams as well. After this I will get started on a front end page to display all of this 

# How to test it
Make a GET request on /api/teams/getall and see that all teams in your database get returned, with players mapped