### PR TITLE
add all games endpoint

### DIFF
--- a/src/CribblyBackend.DataAccess/Repositories/GameRepository.cs
+++ b/src/CribblyBackend.DataAccess/Repositories/GameRepository.cs
@@ -10,7 +10,7 @@ namespace CribblyBackend.DataAccess.Repositories
     public interface IGameRepository
     {
         Task<Game> GetById(int Id);
-        Task<List<Game>> GetByTeamId(int id);
+        Task<IEnumerable<Game>> GetByTeamId(int id);
         void Update(Game Game);
         Task Create(Game Game);
         void Delete(Game Game);
@@ -48,19 +48,17 @@ namespace CribblyBackend.DataAccess.Repositories
             game.Teams = teams.Values.ToList();
             return game;
         }
-        public async Task<List<Game>> GetByTeamId(int id)
+        public async Task<IEnumerable<Game>> GetByTeamId(int id)
         {
             var games = (await connection.QueryAsync<Game, Team, Team, Game>(
                 @"
                     SELECT * FROM Scores s 
                     LEFT JOIN Games g on s.GameId = g.Id 
                     LEFT JOIN Teams t on s.TeamId = t.Id 
-                    LEFT JOIN Scores s2 on s.GameId = g.Id
+                    LEFT JOIN Scores s2 on s.GameId = s2.GameId
                     LEFT JOIN Teams t2 on s2.TeamId = t2.Id
                     WHERE s.TeamId = @id
-                    AND s.GameId = s2.GameId
                     AND s.TeamId != s2.TeamId
-
                 ",
                 (g, t, t2) =>
                 {

--- a/src/CribblyBackend.DataAccess/Repositories/GameRepository.cs
+++ b/src/CribblyBackend.DataAccess/Repositories/GameRepository.cs
@@ -10,6 +10,7 @@ namespace CribblyBackend.DataAccess.Repositories
     public interface IGameRepository
     {
         Task<Game> GetById(int Id);
+        Task<List<Game>> GetByTeamId(int id);
         void Update(Game Game);
         Task Create(Game Game);
         void Delete(Game Game);
@@ -46,6 +47,32 @@ namespace CribblyBackend.DataAccess.Repositories
                 )).FirstOrDefault();
             game.Teams = teams.Values.ToList();
             return game;
+        }
+        public async Task<List<Game>> GetByTeamId(int id)
+        {
+            var games = (await connection.QueryAsync<Game, Team, Team, Game>(
+                @"
+                    SELECT * FROM Scores s 
+                    LEFT JOIN Games g on s.GameId = g.Id 
+                    LEFT JOIN Teams t on s.TeamId = t.Id 
+                    LEFT JOIN Scores s2 on s.GameId = g.Id
+                    LEFT JOIN Teams t2 on s2.TeamId = t2.Id
+                    WHERE s.TeamId = @id
+                    AND s.GameId = s2.GameId
+                    AND s.TeamId != s2.TeamId
+
+                ",
+                (g, t, t2) =>
+                {
+                    g.Teams = new List<Team>();
+                    g.Teams.Add(t);
+                    g.Teams.Add(t2);
+                    return g;
+                },
+                new { Id = id }
+                ));
+
+            return games.ToList();
         }
         public async Task Create(Game game)
         {

--- a/src/CribblyBackend/Controllers/GameController.cs
+++ b/src/CribblyBackend/Controllers/GameController.cs
@@ -36,24 +36,6 @@ namespace CribblyBackend.Controllers
             logger.Information("Request for game {id} returned no results", id);
             return NotFound();
         }
-        
-        /// <summary>
-        /// GetByTeamId fetches all games associated with a given TeamId.
-        /// </summary>
-        /// <param name="id">The id of the Team for which to get all games</param>
-        /// <returns></returns>
-        [HttpGet]
-        [Route("GetByTeamId")]
-        public async Task<IActionResult> GetByTeamId(int id)
-        {
-            var g = await gameService.GetByTeamId(id);
-            if (g.Count() > 0)
-            {
-                return Ok(g);
-            }
-            logger.Information("Request for games from team {id} returned no results", id);
-            return NotFound();
-        }
 
         /// <summary>
         /// Create makes a new Game object.

--- a/src/CribblyBackend/Controllers/GameController.cs
+++ b/src/CribblyBackend/Controllers/GameController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using System.Linq;
 using CribblyBackend.DataAccess.Models;
 using CribblyBackend.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -46,7 +47,7 @@ namespace CribblyBackend.Controllers
         public async Task<IActionResult> GetByTeamId(int id)
         {
             var g = await gameService.GetByTeamId(id);
-            if (g != null)
+            if (g.Count() > 0)
             {
                 return Ok(g);
             }

--- a/src/CribblyBackend/Controllers/GameController.cs
+++ b/src/CribblyBackend/Controllers/GameController.cs
@@ -35,6 +35,24 @@ namespace CribblyBackend.Controllers
             logger.Information("Request for game {id} returned no results", id);
             return NotFound();
         }
+        
+        /// <summary>
+        /// GetByTeamId fetches all games associated with a given TeamId.
+        /// </summary>
+        /// <param name="id">The id of the Team for which to get all games</param>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("GetByTeamId")]
+        public async Task<IActionResult> GetByTeamId(int id)
+        {
+            var g = await gameService.GetByTeamId(id);
+            if (g != null)
+            {
+                return Ok(g);
+            }
+            logger.Information("Request for games from team {id} returned no results", id);
+            return NotFound();
+        }
 
         /// <summary>
         /// Create makes a new Game object.

--- a/src/CribblyBackend/Controllers/TeamController.cs
+++ b/src/CribblyBackend/Controllers/TeamController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using CribblyBackend.DataAccess.Models;
 using CribblyBackend.Services;
@@ -12,12 +13,12 @@ namespace CribblyBackend.Controllers
     [Route("api/[controller]")]
     public class TeamController : ControllerBase
     {
-        private readonly ITeamService teamService;
-        private readonly ILogger logger;
+        private readonly ITeamService _teamService;
+        private readonly ILogger _logger;
         public TeamController(ITeamService teamService, ILogger logger)
         {
-            this.teamService = teamService;
-            this.logger = logger;
+            _teamService = teamService;
+            _logger = logger;
         }
 
         /// <summary>
@@ -28,13 +29,13 @@ namespace CribblyBackend.Controllers
         [HttpGet("{id}")]
         public async Task<IActionResult> GetById(int id)
         {
-            logger.Debug("Received request to get team using id {id}", id);
-            var p = await teamService.GetById(id);
+            _logger.Debug("Received request to get team using id {id}", id);
+            var p = await _teamService.GetById(id);
             if (p != null)
             {
                 return Ok(p);
             }
-            logger.Information("Request for team {id} returned no results", id);
+            _logger.Information("Request for team {id} returned no results", id);
             return NotFound();
         }
 
@@ -48,14 +49,14 @@ namespace CribblyBackend.Controllers
         {
             try
             {
-                logger.Debug("Received request to create team {@team}", team);
-                var createdId = await teamService.Create(team);
-                logger.Debug("New team created: {@team}", team);
+                _logger.Debug("Received request to create team {@team}", team);
+                var createdId = await _teamService.Create(team);
+                _logger.Debug("New team created: {@team}", team);
                 return Ok(createdId);
             }
             catch (Exception e)
             {
-                logger.Information("Failed to create team: {@team} -- MSG: {message}", team, e.Message);
+                _logger.Information("Failed to create team: {@team} -- MSG: {message}", team, e.Message);
                 return StatusCode(500, $"Uh oh, bad time: {e.Message}");
             }
         }
@@ -67,16 +68,34 @@ namespace CribblyBackend.Controllers
         {
             try
             {
-                logger.Debug("Received request to get all teams");
-                var teams = await teamService.Get();
-                logger.Debug("All teams returned");
+                _logger.Debug("Received request to get all teams");
+                var teams = await _teamService.Get();
+                _logger.Debug("All teams returned");
                 return Ok(teams);
             }
             catch (Exception e)
             {
-                logger.Information(e, "Failed to fetch all teams");
+                _logger.Information(e, "Failed to fetch all teams");
                 return StatusCode(500, $"Uh oh, bad time: {e.Message}");
             }
+        }
+
+        /// <summary>
+        /// GetByTeamId fetches all games associated with a given TeamId.
+        /// </summary>
+        /// <param name="id">The id of the Team for which to get all games</param>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("{id}/games")]
+        public async Task<IActionResult> GetByTeamId(int id)
+        {
+            var games = await _teamService.GetGamesAsync(id);
+            if (games.Any())
+            {
+                return Ok(games);
+            }
+            _logger.Information("Request for games from team {id} returned no results", id);
+            return NotFound();
         }
     }
 }

--- a/src/CribblyBackend/Services/GameService.cs
+++ b/src/CribblyBackend/Services/GameService.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using CribblyBackend.DataAccess.Models;
 using CribblyBackend.DataAccess.Repositories;
 
@@ -7,6 +8,7 @@ namespace CribblyBackend.Services
     public interface IGameService
     {
         Task<Game> GetById(int Id);
+        Task<List<Game>> GetByTeamId(int Id);
         void Update(Game Game);
         Task Create(Game Game);
         void Delete(Game Game);
@@ -23,6 +25,10 @@ namespace CribblyBackend.Services
         public async Task<Game> GetById(int id)
         {
             return await _gameRepository.GetById(id);
+        }
+        public async Task<List<Game>> GetByTeamId(int id)
+        {
+            return await _gameRepository.GetByTeamId(id);
         }
         public async Task Create(Game game)
         {

--- a/src/CribblyBackend/Services/GameService.cs
+++ b/src/CribblyBackend/Services/GameService.cs
@@ -8,7 +8,7 @@ namespace CribblyBackend.Services
     public interface IGameService
     {
         Task<Game> GetById(int Id);
-        Task<List<Game>> GetByTeamId(int Id);
+        Task<IEnumerable<Game>> GetByTeamId(int Id);
         void Update(Game Game);
         Task Create(Game Game);
         void Delete(Game Game);
@@ -26,7 +26,7 @@ namespace CribblyBackend.Services
         {
             return await _gameRepository.GetById(id);
         }
-        public async Task<List<Game>> GetByTeamId(int id)
+        public async Task<IEnumerable<Game>> GetByTeamId(int id)
         {
             return await _gameRepository.GetByTeamId(id);
         }

--- a/src/CribblyBackend/Services/GameService.cs
+++ b/src/CribblyBackend/Services/GameService.cs
@@ -8,7 +8,6 @@ namespace CribblyBackend.Services
     public interface IGameService
     {
         Task<Game> GetById(int Id);
-        Task<IEnumerable<Game>> GetByTeamId(int Id);
         void Update(Game Game);
         Task Create(Game Game);
         void Delete(Game Game);
@@ -25,10 +24,6 @@ namespace CribblyBackend.Services
         public async Task<Game> GetById(int id)
         {
             return await _gameRepository.GetById(id);
-        }
-        public async Task<IEnumerable<Game>> GetByTeamId(int id)
-        {
-            return await _gameRepository.GetByTeamId(id);
         }
         public async Task Create(Game game)
         {

--- a/src/CribblyBackend/Services/TeamService.cs
+++ b/src/CribblyBackend/Services/TeamService.cs
@@ -8,6 +8,7 @@ namespace CribblyBackend.Services
     public interface ITeamService
     {
         Task<Team> GetById(int Id);
+        Task<IEnumerable<Game>> GetGamesAsync(int teamId);
         Task<List<Team>> Get();
         void Update(Team Team);
         Task<int> Create(Team Team);
@@ -47,6 +48,11 @@ namespace CribblyBackend.Services
         public void Update(Team team)
         {
             throw new System.NotImplementedException();
+        }
+
+        public async Task<IEnumerable<Game>> GetGamesAsync(int teamId)
+        {
+            return await _gameRepository.GetByTeamId(teamId);
         }
     }
 }


### PR DESCRIPTION
# What I added (link any issues addressed)
An endpoint to return all games that a given team is playing in. This is the first part to building the master Standings table

# How to test it
- Make sure that teams and games exist
- Run the endpoint `/GetByTeamId?id=*id*` and see that a Game is returned for each Game that a team belongs to. Both team objects will also be populated