### PR TITLE
Add standings calculations

### DIFF
--- a/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
+++ b/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
@@ -15,7 +15,7 @@ namespace CribblyBackend.UnitTests
         private readonly Mock<IGameRepository> mockGameRepository;
 
         private Team team1 = new Team() { Id = 1, Name = "team1"};
-        private Team team2 = new Team() { Id = 1, Name = "team2"};
+        private Team team2 = new Team() { Id = 2, Name = "team2"};
 
         public StandingsServiceTests()
         {
@@ -36,8 +36,7 @@ namespace CribblyBackend.UnitTests
         public async Task Calculate_ShouldReturnTeamWithOneLossIfTheyHaveLoss()
         {
             Game game = new Game(){ Teams = new List<Team>(){team1, team2}, Winner = team2};
-            var games = new List<Game>(){game};
-            mockGameRepository.Setup(x => x.GetByTeamId(team1.Id)).ReturnsAsync(games);
+            mockGameRepository.Setup(x => x.GetByTeamId(team1.Id)).ReturnsAsync(new List<Game>(){game});
             var result = await StandingsService.Calculate(team1);
             Assert.Equal(0, result.Wins);
             Assert.Equal(1, result.Losses);

--- a/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
+++ b/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
@@ -33,7 +33,7 @@ namespace CribblyBackend.UnitTests
             Assert.IsType<List<Game>>(result.PlayInGames);
         }
         [Fact]
-        public async Task Calculate_ShouldReturnTeamWithOneWinIfTheyHaveLoss()
+        public async Task Calculate_ShouldReturnTeamWithOneLossIfTheyHaveLoss()
         {
             Game game = new Game(){ Teams = new List<Team>(){team1, team2}, Winner = team2};
             var games = new List<Game>(){game};

--- a/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
+++ b/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Data.Common;
+using System.Threading.Tasks;
+using CribblyBackend.Controllers;
+using CribblyBackend.DataAccess.Models;
+using CribblyBackend.DataAccess.Repositories;
+using CribblyBackend.Services;
+using Dapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.Dapper;
+using Xunit;
+
+namespace CribblyBackend.UnitTests
+{
+    public class StandingsServiceTests
+    {
+        private readonly StandingsService StandingsService;
+        private readonly Mock<IGameRepository> mockGameRepository;
+
+        public StandingsServiceTests()
+        {
+            mockGameRepository = new Mock<IGameRepository>();
+            StandingsService = new StandingsService(mockGameRepository.Object);
+        }
+        [Fact]
+        public async Task Get_ShouldReturnListsForTeamGameProperties()
+        {
+            Team team1 = new Team() { Id = 1, Name = "team1"};
+            Team team2 = new Team() { Id = 1, Name = "team2"};
+            Game game = new Game(){ Teams = new List<Team>(){team1, team2}};
+            var games = new List<Game>(){game};
+            mockGameRepository.Setup(x => x.GetByTeamId(team1.Id)).ReturnsAsync(games);
+            var result = await StandingsService.Calculate(team1);
+            Assert.IsType<List<Game>>(result.BracketGames);
+            Assert.IsType<List<Game>>(result.PlayInGames);
+        }
+    }
+}

--- a/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
+++ b/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
@@ -1,18 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Linq;
-using System.Data.Common;
 using System.Threading.Tasks;
-using CribblyBackend.Controllers;
 using CribblyBackend.DataAccess.Models;
 using CribblyBackend.DataAccess.Repositories;
 using CribblyBackend.Services;
-using Dapper;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Moq;
-using Moq.Dapper;
 using Xunit;
 
 namespace CribblyBackend.UnitTests

--- a/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
+++ b/CribblyBackend.UnitTests/ServiceTests/StandingsServiceTests.cs
@@ -22,22 +22,33 @@ namespace CribblyBackend.UnitTests
         private readonly StandingsService StandingsService;
         private readonly Mock<IGameRepository> mockGameRepository;
 
+        private Team team1 = new Team() { Id = 1, Name = "team1"};
+        private Team team2 = new Team() { Id = 1, Name = "team2"};
+
         public StandingsServiceTests()
         {
             mockGameRepository = new Mock<IGameRepository>();
             StandingsService = new StandingsService(mockGameRepository.Object);
         }
         [Fact]
-        public async Task Get_ShouldReturnListsForTeamGameProperties()
+        public async Task Calculate_ShouldReturnListsForTeamGameProperties()
         {
-            Team team1 = new Team() { Id = 1, Name = "team1"};
-            Team team2 = new Team() { Id = 1, Name = "team2"};
             Game game = new Game(){ Teams = new List<Team>(){team1, team2}};
             var games = new List<Game>(){game};
             mockGameRepository.Setup(x => x.GetByTeamId(team1.Id)).ReturnsAsync(games);
             var result = await StandingsService.Calculate(team1);
             Assert.IsType<List<Game>>(result.BracketGames);
             Assert.IsType<List<Game>>(result.PlayInGames);
+        }
+        [Fact]
+        public async Task Calculate_ShouldReturnTeamWithOneWinIfTheyHaveLoss()
+        {
+            Game game = new Game(){ Teams = new List<Team>(){team1, team2}, Winner = team2};
+            var games = new List<Game>(){game};
+            mockGameRepository.Setup(x => x.GetByTeamId(team1.Id)).ReturnsAsync(games);
+            var result = await StandingsService.Calculate(team1);
+            Assert.Equal(0, result.Wins);
+            Assert.Equal(1, result.Losses);
         }
     }
 }

--- a/CribblyBackend.UnitTests/ServiceTests/TeamServiceTests.cs
+++ b/CribblyBackend.UnitTests/ServiceTests/TeamServiceTests.cs
@@ -32,7 +32,7 @@ namespace CribblyBackend.UnitTests
             mockGameRepository = new Mock<IGameRepository>();
             mockStandingsService = new Mock<IStandingsService>();
             gameService = new GameService(mockGameRepository.Object);
-            teamService = new TeamService(mockTeamRepository.Object, mockStandingsService.Object);
+            teamService = new TeamService(mockTeamRepository.Object, mockStandingsService.Object, mockGameRepository.Object);
             standingsService = new StandingsService(mockGameRepository.Object);
         }
         [Fact]

--- a/CribblyBackend.UnitTests/ServiceTests/TeamServiceTests.cs
+++ b/CribblyBackend.UnitTests/ServiceTests/TeamServiceTests.cs
@@ -21,15 +21,19 @@ namespace CribblyBackend.UnitTests
     {
         private readonly TeamService teamService;
         private readonly GameService gameService;
+        private readonly StandingsService standingsService;
         private readonly Mock<ITeamRepository> mockTeamRepository;
         private readonly Mock<IGameRepository> mockGameRepository;
+        private readonly Mock<IStandingsService> mockStandingsService;
 
         public TeamServiceTests()
         {
             mockTeamRepository = new Mock<ITeamRepository>();
             mockGameRepository = new Mock<IGameRepository>();
+            mockStandingsService = new Mock<IStandingsService>();
             gameService = new GameService(mockGameRepository.Object);
-            teamService = new TeamService(mockTeamRepository.Object, mockGameRepository.Object);
+            teamService = new TeamService(mockTeamRepository.Object, mockStandingsService.Object);
+            standingsService = new StandingsService(mockGameRepository.Object);
         }
         [Fact]
         public async Task CreateTeamWithOnePlayer_ShouldThrowError()
@@ -51,11 +55,12 @@ namespace CribblyBackend.UnitTests
                 new Team() { Name = "team1" },
                 new Team() { Name = "team2" }
             };
+
             mockTeamRepository.Setup( x => x.Get()).ReturnsAsync(teams);
+            
             var teamsList = await teamService.Get();
             Assert.True(TeamListHasNoDuplicates(teamsList));
         }
-
         public bool TeamListHasNoDuplicates(List<Team> teams)
         {
             return teams.GroupBy(t => t.Id).Any(grp => grp.Count() > 1);

--- a/src/CribblyBackend.DataAccess/Repositories/GameRepository.cs
+++ b/src/CribblyBackend.DataAccess/Repositories/GameRepository.cs
@@ -60,7 +60,6 @@ namespace CribblyBackend.DataAccess.Repositories
                     WHERE s.TeamId = @id
                     AND s.GameId = s2.GameId
                     AND s.TeamId != s2.TeamId
-
                 ",
                 (g, t, t2) =>
                 {

--- a/src/CribblyBackend/Controllers/StandingsController.cs
+++ b/src/CribblyBackend/Controllers/StandingsController.cs
@@ -24,7 +24,7 @@ namespace CribblyBackend.Controllers
         /// <summary>
         /// Returns a Team object with standings filled in.
         /// </summary>
-        /// <param name="request">The request</param>
+        /// <param name="team">The team for which to get standings</param>
         /// <returns></returns>
         [HttpPost]
         [Route("Calculate")]

--- a/src/CribblyBackend/Controllers/StandingsController.cs
+++ b/src/CribblyBackend/Controllers/StandingsController.cs
@@ -27,7 +27,8 @@ namespace CribblyBackend.Controllers
         /// <param name="request">The request</param>
         /// <returns></returns>
         [HttpPost]
-        public async Task<IActionResult> Get([FromBody] Team team)
+        [Route("Calculate")]
+        public async Task<IActionResult> Calculate([FromBody] Team team)
         {
             try
             {

--- a/src/CribblyBackend/Controllers/StandingsController.cs
+++ b/src/CribblyBackend/Controllers/StandingsController.cs
@@ -13,12 +13,12 @@ namespace CribblyBackend.Controllers
     [Route("api/[controller]")]
     public class StandingsController : ControllerBase
     {
-        private readonly IStandingsService StandingsService;
-        private readonly ILogger logger;
-        public StandingsController(IStandingsService StandingsService, ILogger logger)
+        private readonly IStandingsService _standingsService;
+        private readonly ILogger _logger;
+        public StandingsController(IStandingsService standingsService, ILogger logger)
         {
-            this.StandingsService = StandingsService;
-            this.logger = logger;
+            _standingsService = standingsService;
+            _logger = logger;
         }
 
         /// <summary>
@@ -32,12 +32,12 @@ namespace CribblyBackend.Controllers
         {
             try
             {
-                var standing = await StandingsService.Calculate(team);
+                var standing = await _standingsService.Calculate(team);
                 return Ok(standing);
             }
             catch (Exception ex)
             {
-                logger.Information(ex, "Failed to get standings");
+                _logger.Information(ex, "Failed to get standings");
                 return StatusCode(500, $"Failed to get standings: {ex.Message}");
             }
 

--- a/src/CribblyBackend/Controllers/StandingsController.cs
+++ b/src/CribblyBackend/Controllers/StandingsController.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using CribblyBackend.DataAccess.Models;
+using CribblyBackend.Network;
+using CribblyBackend.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using Serilog;
+
+namespace CribblyBackend.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class StandingsController : ControllerBase
+    {
+        private readonly IStandingsService StandingsService;
+        private readonly ILogger logger;
+        public StandingsController(IStandingsService StandingsService, ILogger logger)
+        {
+            this.StandingsService = StandingsService;
+            this.logger = logger;
+        }
+
+        /// <summary>
+        /// Returns a Team object with standings filled in.
+        /// </summary>
+        /// <param name="request">The request</param>
+        /// <returns></returns>
+        [HttpPost]
+        public async Task<IActionResult> Get([FromBody] Team team)
+        {
+            try
+            {
+                var standing = await StandingsService.Calculate(team);
+                return Ok(standing);
+            }
+            catch (Exception ex)
+            {
+                logger.Information(ex, "Failed to get standings");
+                return StatusCode(500, $"Failed to get standings: {ex.Message}");
+            }
+
+        }
+    }
+}

--- a/src/CribblyBackend/Services/StandingsService.cs
+++ b/src/CribblyBackend/Services/StandingsService.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using CribblyBackend.DataAccess.Models;
+using CribblyBackend.DataAccess.Repositories;
+
+namespace CribblyBackend.Services
+{
+    public interface IStandingsService
+    {
+        Task<Team> Calculate(Team team);
+    }
+
+    public class StandingsService : IStandingsService
+    {
+        private readonly IGameRepository _gameRepository;
+        public StandingsService(IGameRepository gameRepository)
+        {
+            _gameRepository = gameRepository;
+        }
+        public async Task<Team> Calculate(Team team)
+        {
+            var allGames = await _gameRepository.GetByTeamId(team.Id);
+            team.PlayInGames = allGames.Where(g => g.GameRound <= Game.Round.Round3).ToList();
+            team.BracketGames = allGames.Where(g => g.GameRound >= Game.Round.TourneyRound1).ToList();
+
+            team.Wins = allGames.Where(g => g.Winner != null && g.Winner.Name == team.Name).ToList().Count;
+            team.Losses = allGames.Where(g => g.Winner != null && g.Winner.Name != team.Name).ToList().Count;
+
+            foreach(Game game in allGames)
+            {
+                if (game.Winner != null && game.Winner.Name == team.Name)
+                {
+                    team.TotalScore += 121;
+                }
+                else if (game.Winner != null)
+                {
+                    team.TotalScore += (121 - game.ScoreDifference);
+                }
+            }
+
+            return team;
+        }
+    }
+
+
+}

--- a/src/CribblyBackend/Services/StandingsService.cs
+++ b/src/CribblyBackend/Services/StandingsService.cs
@@ -24,8 +24,8 @@ namespace CribblyBackend.Services
             team.PlayInGames = allGames.Where(g => g.GameRound <= Game.Round.Round3).ToList();
             team.BracketGames = allGames.Where(g => g.GameRound >= Game.Round.TourneyRound1).ToList();
 
-            team.Wins = allGames.Count(g => g.Winner != null && g.Winner.Id == team.Id);
-            team.Losses = allGames.Count(g => g.Winner != null && g.Winner.Id != team.Id);
+            team.Wins = allGames.Count(g => g.Winner != null && g.Winner.Name == team.Name);
+            team.Losses = allGames.Count(g => g.Winner != null && g.Winner.Name != team.Name);
 
             foreach(Game game in allGames)
             {

--- a/src/CribblyBackend/Services/StandingsService.cs
+++ b/src/CribblyBackend/Services/StandingsService.cs
@@ -24,8 +24,8 @@ namespace CribblyBackend.Services
             team.PlayInGames = allGames.Where(g => g.GameRound <= Game.Round.Round3).ToList();
             team.BracketGames = allGames.Where(g => g.GameRound >= Game.Round.TourneyRound1).ToList();
 
-            team.Wins = allGames.Where(g => g.Winner != null && g.Winner.Name == team.Name).ToList().Count;
-            team.Losses = allGames.Where(g => g.Winner != null && g.Winner.Name != team.Name).ToList().Count;
+            team.Wins = allGames.Count(g => g.Winner != null && g.Winner.Id == team.Id);
+            team.Losses = allGames.Count(g => g.Winner != null && g.Winner.Id != team.Id);
 
             foreach(Game game in allGames)
             {

--- a/src/CribblyBackend/Services/StandingsService.cs
+++ b/src/CribblyBackend/Services/StandingsService.cs
@@ -24,8 +24,8 @@ namespace CribblyBackend.Services
             team.PlayInGames = allGames.Where(g => g.GameRound <= Game.Round.Round3).ToList();
             team.BracketGames = allGames.Where(g => g.GameRound >= Game.Round.TourneyRound1).ToList();
 
-            team.Wins = allGames.Count(g => g.Winner != null && g.Winner.Name == team.Name);
-            team.Losses = allGames.Count(g => g.Winner != null && g.Winner.Name != team.Name);
+            team.Wins = allGames.Count(g => g.Winner != null && g.Winner.Id == team.Id);
+            team.Losses = allGames.Count(g => g.Winner != null && g.Winner.Id != team.Id);
 
             foreach(Game game in allGames)
             {

--- a/src/CribblyBackend/Services/TeamService.cs
+++ b/src/CribblyBackend/Services/TeamService.cs
@@ -18,11 +18,13 @@ namespace CribblyBackend.Services
     {
         private readonly ITeamRepository _teamRepository;
         private readonly IStandingsService _standingsService;
+        private readonly IGameRepository _gameRepository;
 
-        public TeamService(ITeamRepository teamRepository, IStandingsService standingsService)
+        public TeamService(ITeamRepository teamRepository, IStandingsService standingsService, IGameRepository gameRepository)
         {
             _teamRepository = teamRepository;
             _standingsService = standingsService;
+            _gameRepository = gameRepository;
         }
         public async Task<List<Team>> Get()
         {

--- a/src/CribblyBackend/Services/TeamService.cs
+++ b/src/CribblyBackend/Services/TeamService.cs
@@ -39,8 +39,7 @@ namespace CribblyBackend.Services
 
         public async Task<Team> GetById(int id)
         {
-            var team = await _teamRepository.GetById(id);
-            return team;
+            return await _teamRepository.GetById(id);;
         }
         public void Update(Team team)
         {

--- a/src/CribblyBackend/Services/TeamService.cs
+++ b/src/CribblyBackend/Services/TeamService.cs
@@ -16,19 +16,16 @@ namespace CribblyBackend.Services
     public class TeamService : ITeamService
     {
         private readonly ITeamRepository _teamRepository;
-        private readonly IGameRepository _gameRepository;
+        private readonly IStandingsService _standingsService;
 
-        public TeamService(ITeamRepository teamRepository, IGameRepository gameRepository)
+        public TeamService(ITeamRepository teamRepository, IStandingsService standingsService)
         {
             _teamRepository = teamRepository;
-            _gameRepository = gameRepository;
+            _standingsService = standingsService;
         }
         public async Task<List<Team>> Get()
         {
-            var teams = await _teamRepository.Get();
-            //TODO: Calculate wins, losses, 
-
-            return teams;
+            return await _teamRepository.Get();
         }
         public async Task<int> Create(Team team)
         {
@@ -42,7 +39,8 @@ namespace CribblyBackend.Services
 
         public async Task<Team> GetById(int id)
         {
-            return await _teamRepository.GetById(id);
+            var team = await _teamRepository.GetById(id);
+            return team;
         }
         public void Update(Team team)
         {

--- a/src/CribblyBackend/Startup.cs
+++ b/src/CribblyBackend/Startup.cs
@@ -61,6 +61,7 @@ namespace CribblyBackend
             services.AddTransient<ITeamService, TeamService>();
             services.AddTransient<IGameService, GameService>();
             services.AddTransient<ITournamentService, TournamentService>();
+            services.AddTransient<IStandingsService, StandingsService>();
             // repositories
             services.AddTransient<IPlayerRepository, PlayerRepository>();
             services.AddTransient<ITeamRepository, TeamRepository>();


### PR DESCRIPTION
# What I added (link any issues addressed)
A controller and service that will handle the processing of standings based on the stored data

# How to test it
- Call ```/standings/calculate``` with a Team object in the body
- See that a Team object is returned
- Ensure that there is at least one Game in the database with a Winner recorded
- Run the endpoint against one of those teams, and the standings should reflect the changes